### PR TITLE
feat(team): 팀 가입 신청 승인/거절 구현

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -236,7 +236,24 @@
 - OWNER는 권한 위임 없이 팀 탈퇴 불가
 - OWNER 변경은 명시적 권한 위임으로 처리
 - 팀에는 최대 허용 멤버 수를 두지 않는다.
+- 팀 승인/거절 구현에서 `currentMemberCount`, `maxMemberCount` 기반 로직은 사용하지 않는다.
 - 팀 가입 신청 중복 방지 필수
+
+## Phase 3 TeamApplication Policy
+
+- Phase 3의 핵심은 TeamApplication 승인/거절 상태 전이의 정합성이다.
+- 팀 가입 신청의 승인/거절은 해당 팀의 OWNER만 수행할 수 있다.
+- `PENDING` 상태의 신청만 승인 또는 거절할 수 있다.
+- 승인 시 `TeamMember`를 생성하고 `TeamApplication` 상태를 `APPROVED`로 변경한다.
+- 거절 시 `TeamApplication` 상태를 `REJECTED`로 변경한다.
+- 승인 시 같은 사용자와 같은 카테고리의 다른 `PENDING` 신청은 자동으로 `CANCELED` 처리한다.
+- 승인/거절 처리는 반드시 하나의 `@Transactional` 경계 안에서 수행한다.
+- 같은 신청의 동시 승인/거절 처리를 막기 위해 승인/거절 대상 `TeamApplication`에는 `PESSIMISTIC_WRITE` 락을 적용한다.
+- 동일 사용자와 동일 팀의 `TeamMember` 중복 생성은 애플리케이션 검증과 DB unique constraint로 방지한다.
+- 동일 사용자와 동일 카테고리의 중복 소속은 `UserCategoryMembership`의 `unique(user_id, category)`로 DB 레벨에서 방어한다.
+- `TeamMember`는 팀 내부 멤버십을 담당하고, `UserCategoryMembership`은 카테고리 단위 소속 제약을 담당한다.
+- 현재 category는 문자열 기반이며, 장기적으로 enum 또는 `Category` 테이블 분리를 검토한다.
+- 정원 정책은 없으므로 승인 로직에서 팀 정원이나 멤버 수 카운터를 검증하지 않는다.
 
 ## User Policy
 
@@ -260,6 +277,10 @@
 중 하나를 상황에 맞게 선택한다.
 
 Trade-off를 설명한다.
+
+Phase 3 승인/거절 구현에서는 우선 `TeamApplication` `PESSIMISTIC_WRITE` 락을 사용한다.
+`TeamMember` 중복 생성은 DB unique constraint를 최종 방어선으로 유지한다.
+같은 카테고리 중복 소속은 `UserCategoryMembership` unique constraint를 최종 방어선으로 유지한다.
 
 ---
 

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -65,6 +65,7 @@
 - 팀 생성 시 `TeamMember`가 함께 생성되어야 한다.
 - 팀은 카테고리를 가진다. 
 - 각 팀에는 멤버 수에 대한 정원이 없다.
+- 팀 가입 승인 처리에서 `currentMemberCount`, `maxMemberCount` 기반 로직은 사용하지 않는다.
 
 ### 3.2 팀 상태
 - 팀은 최소한 다음 상태를 가진다.
@@ -136,6 +137,7 @@
 - 팀 가입 신청의 승인/거절은 해당 팀의 `OWNER`만 수행할 수 있다.
 - 다른 팀의 `OWNER`는 권한이 없다.
 - 일반 팀원은 승인/거절 권한이 없다.
+- 승인/거절 권한은 `TeamMember`의 `role`과 활성 상태를 기준으로 검증한다.
 
 ### 5.2 승인 처리
 - 승인 시 다음 작업은 하나의 트랜잭션 안에서 처리한다.
@@ -146,19 +148,26 @@
     5. `TeamMember` 생성
     6. 신청 상태를 `APPROVED`로 변경
     7. 같은 카테고리의 다른 `PENDING` 신청을 `CANCELED`로 변경
+- `PENDING` 상태의 신청만 승인할 수 있다.
+- 승인 시 `TeamMember` 생성과 `TeamApplication` 상태 변경은 반드시 하나의 `@Transactional` 경계 안에서 처리한다.
+- 같은 신청은 중복 승인될 수 없다.
+- 같은 사용자와 같은 팀의 `TeamMember` 중복 생성은 애플리케이션 검증으로 먼저 막고, DB unique constraint를 최종 방어선으로 둔다.
+- 같은 사용자와 같은 카테고리의 중복 소속은 `UserCategoryMembership`의 `unique(user_id, category)` 제약을 최종 방어선으로 둔다.
+- `TeamMember`는 팀 내부 멤버십을 표현하고, `UserCategoryMembership`은 사용자-카테고리 단위 소속 제약을 표현한다.
+- 현재 category는 문자열 기반이며, 장기적으로 enum 또는 별도 `Category` 테이블 분리를 검토한다.
 
 ### 5.3 거절 처리
+- `PENDING` 상태의 신청만 거절할 수 있다.
 - 거절 시 신청 상태를 `REJECTED`로 변경한다.
 - `REJECTED` 신청은 이후 재신청할 수 있다.
+- 거절 처리는 반드시 `@Transactional` 경계 안에서 수행한다.
+- 같은 신청은 중복 거절되거나 승인 후 거절될 수 없다.
 
 ### 5.4 동시성 제어
 - 같은 카테고리의 여러 팀에 동시에 승인 요청이 들어와도 한 회원은 하나의 팀에만 소속되어야 한다.
-- 승인 로직은 비관적 락 또는 낙관적 락으로 보호한다.
-- 우선 구현은 비관적 락을 권장한다.
-- 최소한 다음 대상의 동시성 보호가 필요하다.
-    - 승인 대상 `Team`
-    - 승인 대상 `TeamApplication`
-    - 신청자의 같은 카테고리 소속 여부 검증
+- 같은 신청의 동시 승인/거절 처리를 막기 위해 승인/거절 대상 `TeamApplication` 조회에는 `PESSIMISTIC_WRITE` 락을 적용한다.
+- 같은 카테고리 중복 소속은 애플리케이션 검증과 `UserCategoryMembership` DB unique constraint로 방지하고, `TeamMember` 중복 생성은 DB unique constraint를 최종 방어선으로 둔다.
+- 팀에는 멤버 정원이 없으므로 승인 동시성 설계에서 정원 기반 검증은 고려하지 않는다.
 
 ### 5.5 승인 관련 예외 메시지
 - 이미 처리된 신청인 경우: `이미 처리된 신청입니다`

--- a/src/main/java/com/neomango/team/controller/TeamApplicationController.java
+++ b/src/main/java/com/neomango/team/controller/TeamApplicationController.java
@@ -3,6 +3,7 @@ package com.neomango.team.controller;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,5 +33,29 @@ public class TeamApplicationController {
 		}
 
 		return ApiResponse.success(teamApplicationService.cancelApplication(applicationId, currentUser.userId()));
+	}
+
+	@PostMapping("/{applicationId}/approve")
+	public ApiResponse<TeamApplicationResponse> approveTeamApplication(
+		@AuthenticationPrincipal AuthenticatedUser currentUser,
+		@PathVariable Long applicationId
+	) {
+		if (currentUser == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		return ApiResponse.success(teamApplicationService.approveApplication(applicationId, currentUser.userId()));
+	}
+
+	@PostMapping("/{applicationId}/reject")
+	public ApiResponse<TeamApplicationResponse> rejectTeamApplication(
+		@AuthenticationPrincipal AuthenticatedUser currentUser,
+		@PathVariable Long applicationId
+	) {
+		if (currentUser == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		return ApiResponse.success(teamApplicationService.rejectApplication(applicationId, currentUser.userId()));
 	}
 }

--- a/src/main/java/com/neomango/team/entity/TeamApplication.java
+++ b/src/main/java/com/neomango/team/entity/TeamApplication.java
@@ -2,6 +2,7 @@ package com.neomango.team.entity;
 
 import java.time.LocalDateTime;
 
+import com.neomango.team.exception.ApplicationAlreadyProcessedException;
 import com.neomango.user.entity.User;
 
 import jakarta.persistence.Column;
@@ -47,6 +48,9 @@ public class TeamApplication {
 	private String message;
 
 	@Column(nullable = false)
+	private boolean active;
+
+	@Column(nullable = false)
 	private LocalDateTime createdAt;
 
 	@Column(nullable = false)
@@ -59,6 +63,7 @@ public class TeamApplication {
 		this.applicant = applicant;
 		this.status = TeamApplicationStatus.PENDING;
 		this.message = message;
+		this.active = true;
 	}
 
 	public static TeamApplication create(Team team, User applicant, String message) {
@@ -66,16 +71,28 @@ public class TeamApplication {
 	}
 
 	public void cancel() {
+		validatePending();
 		this.status = TeamApplicationStatus.CANCELED;
+		this.active = false;
 		this.canceledAt = LocalDateTime.now();
 	}
 
 	public void approve() {
+		validatePending();
 		this.status = TeamApplicationStatus.APPROVED;
+		this.active = false;
 	}
 
 	public void reject() {
+		validatePending();
 		this.status = TeamApplicationStatus.REJECTED;
+		this.active = false;
+	}
+
+	public void validatePending() {
+		if (this.status != TeamApplicationStatus.PENDING) {
+			throw new ApplicationAlreadyProcessedException();
+		}
 	}
 
 	@PrePersist

--- a/src/main/java/com/neomango/team/entity/UserCategoryMembership.java
+++ b/src/main/java/com/neomango/team/entity/UserCategoryMembership.java
@@ -1,0 +1,66 @@
+package com.neomango.team.entity;
+
+import java.time.LocalDateTime;
+
+import com.neomango.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+	name = "user_category_memberships",
+	uniqueConstraints = @UniqueConstraint(
+		name = "uk_user_category_memberships_user_category",
+		columnNames = {"user_id", "category"}
+	)
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserCategoryMembership {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(nullable = false, length = 50)
+	private String category;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "team_id", nullable = false)
+	private Team team;
+
+	@Column(nullable = false)
+	private LocalDateTime createdAt;
+
+	private UserCategoryMembership(User user, String category, Team team) {
+		this.user = user;
+		this.category = category;
+		this.team = team;
+	}
+
+	public static UserCategoryMembership create(User user, String category, Team team) {
+		return new UserCategoryMembership(user, category, team);
+	}
+
+	@PrePersist
+	void prePersist() {
+		this.createdAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/neomango/team/exception/ApplicationAlreadyProcessedException.java
+++ b/src/main/java/com/neomango/team/exception/ApplicationAlreadyProcessedException.java
@@ -1,0 +1,11 @@
+package com.neomango.team.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class ApplicationAlreadyProcessedException extends BusinessException {
+
+	public ApplicationAlreadyProcessedException() {
+		super(ErrorCode.INVALID_TEAM_APPLICATION_STATUS);
+	}
+}

--- a/src/main/java/com/neomango/team/exception/DuplicateTeamMemberException.java
+++ b/src/main/java/com/neomango/team/exception/DuplicateTeamMemberException.java
@@ -1,0 +1,11 @@
+package com.neomango.team.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class DuplicateTeamMemberException extends BusinessException {
+
+	public DuplicateTeamMemberException() {
+		super(ErrorCode.DUPLICATE_TEAM_MEMBER);
+	}
+}

--- a/src/main/java/com/neomango/team/exception/NotTeamOwnerException.java
+++ b/src/main/java/com/neomango/team/exception/NotTeamOwnerException.java
@@ -1,0 +1,11 @@
+package com.neomango.team.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class NotTeamOwnerException extends BusinessException {
+
+	public NotTeamOwnerException() {
+		super(ErrorCode.TEAM_OWNER_REQUIRED);
+	}
+}

--- a/src/main/java/com/neomango/team/repository/TeamApplicationRepository.java
+++ b/src/main/java/com/neomango/team/repository/TeamApplicationRepository.java
@@ -3,12 +3,15 @@ package com.neomango.team.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.neomango.team.entity.TeamApplication;
 import com.neomango.team.entity.TeamApplicationStatus;
+
+import jakarta.persistence.LockModeType;
 
 public interface TeamApplicationRepository extends JpaRepository<TeamApplication, Long> {
 
@@ -33,6 +36,16 @@ public interface TeamApplicationRepository extends JpaRepository<TeamApplication
 		""")
 	Optional<TeamApplication> findByIdWithTeam(@Param("applicationId") Long applicationId);
 
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("""
+		select application
+		from TeamApplication application
+		join fetch application.team
+		join fetch application.applicant
+		where application.id = :applicationId
+		""")
+	Optional<TeamApplication> findByIdForUpdate(@Param("applicationId") Long applicationId);
+
 	@Query("""
 		select application
 		from TeamApplication application
@@ -54,5 +67,20 @@ public interface TeamApplicationRepository extends JpaRepository<TeamApplication
 	List<TeamApplication> findByTeamIdAndStatusWithApplicantOrderByCreatedAtAsc(
 		@Param("teamId") Long teamId,
 		@Param("status") TeamApplicationStatus status
+	);
+
+	@Query("""
+		select application
+		from TeamApplication application
+		join fetch application.team team
+		where application.applicant.id = :applicantId
+			and team.category = :category
+			and application.status = com.neomango.team.entity.TeamApplicationStatus.PENDING
+			and application.id <> :applicationId
+		""")
+	List<TeamApplication> findOtherPendingApplicationsInSameCategory(
+		@Param("applicationId") Long applicationId,
+		@Param("applicantId") Long applicantId,
+		@Param("category") String category
 	);
 }

--- a/src/main/java/com/neomango/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/neomango/team/repository/TeamMemberRepository.java
@@ -35,6 +35,10 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
 	Optional<TeamMember> findByTeamIdAndRole(Long teamId, TeamMemberRole role);
 
+	boolean existsByTeamIdAndUserId(Long teamId, Long userId);
+
+	long countByTeamIdAndUserId(Long teamId, Long userId);
+
 	boolean existsByTeamIdAndUserIdAndStatus(Long teamId, Long userId, TeamMemberStatus status);
 
 	@Query("""

--- a/src/main/java/com/neomango/team/repository/UserCategoryMembershipRepository.java
+++ b/src/main/java/com/neomango/team/repository/UserCategoryMembershipRepository.java
@@ -1,0 +1,12 @@
+package com.neomango.team.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.neomango.team.entity.UserCategoryMembership;
+
+public interface UserCategoryMembershipRepository extends JpaRepository<UserCategoryMembership, Long> {
+
+	boolean existsByUserIdAndCategory(Long userId, String category);
+
+	long countByUserIdAndCategory(Long userId, String category);
+}

--- a/src/main/java/com/neomango/team/service/TeamApplicationService.java
+++ b/src/main/java/com/neomango/team/service/TeamApplicationService.java
@@ -2,6 +2,7 @@ package com.neomango.team.service;
 
 import java.util.List;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,9 +19,13 @@ import com.neomango.team.entity.TeamMember;
 import com.neomango.team.entity.TeamMemberRole;
 import com.neomango.team.entity.TeamMemberStatus;
 import com.neomango.team.entity.TeamStatus;
+import com.neomango.team.entity.UserCategoryMembership;
+import com.neomango.team.exception.DuplicateTeamMemberException;
+import com.neomango.team.exception.NotTeamOwnerException;
 import com.neomango.team.repository.TeamApplicationRepository;
 import com.neomango.team.repository.TeamMemberRepository;
 import com.neomango.team.repository.TeamRepository;
+import com.neomango.team.repository.UserCategoryMembershipRepository;
 import com.neomango.user.entity.User;
 import com.neomango.user.entity.UserStatus;
 import com.neomango.user.repository.UserRepository;
@@ -35,6 +40,7 @@ public class TeamApplicationService {
 	private final TeamApplicationRepository teamApplicationRepository;
 	private final TeamRepository teamRepository;
 	private final TeamMemberRepository teamMemberRepository;
+	private final UserCategoryMembershipRepository userCategoryMembershipRepository;
 	private final UserRepository userRepository;
 
 	public TeamApplicationResponse createApplication(
@@ -74,6 +80,49 @@ public class TeamApplicationService {
 		teamApplication.cancel();
 
 		return TeamApplicationResponse.from(teamApplication);
+	}
+
+	public TeamApplicationResponse approveApplication(Long applicationId, Long loginUserId) {
+		if (loginUserId == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		TeamApplication application = teamApplicationRepository.findByIdForUpdate(applicationId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.TEAM_APPLICATION_NOT_FOUND));
+		application.validatePending();
+
+		Team team = application.getTeam();
+		User applicant = application.getApplicant();
+		validateApplicationProcessOwner(team, loginUserId);
+		validateNoDuplicateTeamMember(team, applicant);
+		validateApplicantIsNotTeamMember(team, applicant);
+		validateApplicantIsNotSameCategoryMember(team, applicant);
+		createUserCategoryMembership(applicant, team);
+
+		TeamMember teamMember = TeamMember.createMember(team, applicant);
+		team.addMember(teamMember);
+		teamMemberRepository.save(teamMember);
+
+		application.approve();
+		cancelOtherPendingApplicationsInSameCategory(application);
+
+		return TeamApplicationResponse.from(application);
+	}
+
+	public TeamApplicationResponse rejectApplication(Long applicationId, Long loginUserId) {
+		if (loginUserId == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		TeamApplication application = teamApplicationRepository.findByIdForUpdate(applicationId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.TEAM_APPLICATION_NOT_FOUND));
+		application.validatePending();
+
+		validateApplicationProcessOwner(application.getTeam(), loginUserId);
+
+		application.reject();
+
+		return TeamApplicationResponse.from(application);
 	}
 
 	@Transactional(readOnly = true)
@@ -140,12 +189,43 @@ public class TeamApplicationService {
 	}
 
 	private void validateApplicantIsNotSameCategoryMember(Team team, User applicant) {
+		if (userCategoryMembershipRepository.existsByUserIdAndCategory(applicant.getId(), team.getCategory())) {
+			throw new BusinessException(ErrorCode.ALREADY_CATEGORY_TEAM_MEMBER);
+		}
+
 		if (teamMemberRepository.existsActiveMemberByUserIdAndTeamCategory(
 			applicant.getId(),
 			team.getCategory()
 		)) {
 			throw new BusinessException(ErrorCode.ALREADY_CATEGORY_TEAM_MEMBER);
 		}
+	}
+
+	private void createUserCategoryMembership(User applicant, Team team) {
+		try {
+			userCategoryMembershipRepository.saveAndFlush(
+				UserCategoryMembership.create(applicant, team.getCategory(), team)
+			);
+		}
+		catch (DataIntegrityViolationException exception) {
+			// TODO: 여러 unique constraint를 한 곳에서 처리하게 되면 constraint name 기반 분기를 검토한다.
+			throw new BusinessException(ErrorCode.ALREADY_CATEGORY_TEAM_MEMBER);
+		}
+	}
+
+	private void validateNoDuplicateTeamMember(Team team, User applicant) {
+		if (teamMemberRepository.existsByTeamIdAndUserId(team.getId(), applicant.getId())) {
+			throw new DuplicateTeamMemberException();
+		}
+	}
+
+	private void cancelOtherPendingApplicationsInSameCategory(TeamApplication approvedApplication) {
+		teamApplicationRepository.findOtherPendingApplicationsInSameCategory(
+				approvedApplication.getId(),
+				approvedApplication.getApplicant().getId(),
+				approvedApplication.getTeam().getCategory()
+			)
+			.forEach(TeamApplication::cancel);
 	}
 
 	private void validateNoPendingApplication(Team team, User applicant) {
@@ -176,6 +256,17 @@ public class TeamApplicationService {
 
 		if (!ownerMember.getUser().getId().equals(requesterId) || ownerMember.getStatus() != TeamMemberStatus.ACTIVE) {
 			throw new BusinessException(ErrorCode.TEAM_APPLICATION_LIST_OWNER_REQUIRED);
+		}
+	}
+
+	private void validateApplicationProcessOwner(Team team, Long loginUserId) {
+		TeamMember ownerMember = teamMemberRepository.findByTeamIdAndRole(team.getId(), TeamMemberRole.OWNER)
+			.orElseThrow(NotTeamOwnerException::new);
+
+		if (!ownerMember.getUser().getId().equals(loginUserId)
+			|| ownerMember.getRole() != TeamMemberRole.OWNER
+			|| ownerMember.getStatus() != TeamMemberStatus.ACTIVE) {
+			throw new NotTeamOwnerException();
 		}
 	}
 }

--- a/src/test/java/com/neomango/team/controller/TeamApplicationControllerTest.java
+++ b/src/test/java/com/neomango/team/controller/TeamApplicationControllerTest.java
@@ -2,9 +2,11 @@ package com.neomango.team.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,9 +19,12 @@ import com.neomango.auth.jwt.JwtTokenProvider;
 import com.neomango.team.entity.Team;
 import com.neomango.team.entity.TeamApplication;
 import com.neomango.team.entity.TeamApplicationStatus;
-import com.neomango.team.repository.TeamApplicationRepository;
+import com.neomango.team.entity.TeamMember;
+import com.neomango.team.entity.UserCategoryMembership;
 import com.neomango.team.repository.TeamMemberRepository;
+import com.neomango.team.repository.TeamApplicationRepository;
 import com.neomango.team.repository.TeamRepository;
+import com.neomango.team.repository.UserCategoryMembershipRepository;
 import com.neomango.user.entity.User;
 import com.neomango.user.entity.UserRole;
 import com.neomango.user.repository.UserRepository;
@@ -45,11 +50,24 @@ class TeamApplicationControllerTest {
 	private TeamMemberRepository teamMemberRepository;
 
 	@Autowired
+	private UserCategoryMembershipRepository userCategoryMembershipRepository;
+
+	@Autowired
 	private TeamApplicationRepository teamApplicationRepository;
 
 	@BeforeEach
 	void setUp() {
+		cleanUp();
+	}
+
+	@AfterEach
+	void tearDown() {
+		cleanUp();
+	}
+
+	private void cleanUp() {
 		teamApplicationRepository.deleteAll();
+		userCategoryMembershipRepository.deleteAll();
 		teamMemberRepository.deleteAll();
 		teamRepository.deleteAll();
 		userRepository.deleteAll();
@@ -84,5 +102,249 @@ class TeamApplicationControllerTest {
 	void cancelTeamApplicationRejectsRequestWithoutAuthentication() throws Exception {
 		mockMvc.perform(patch("/api/team-applications/{applicationId}/cancel", 1L))
 			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void approveApplication_returnsApprovedStatusWhenRequesterIsOwner() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
+		Team team = teamRepository.save(Team.create("Futsal Team", null, "FUTSAL", owner));
+		TeamApplication application = teamApplicationRepository.save(
+			TeamApplication.create(team, applicant, "가입하고 싶습니다.")
+		);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/team-applications/{applicationId}/approve", application.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.applicationId").value(application.getId()))
+			.andExpect(jsonPath("$.data.teamId").value(team.getId()))
+			.andExpect(jsonPath("$.data.teamName").value("Futsal Team"))
+			.andExpect(jsonPath("$.data.status").value("APPROVED"))
+			.andExpect(jsonPath("$.data.message").value("가입하고 싶습니다."));
+
+		TeamApplication approvedApplication = teamApplicationRepository.findById(application.getId()).orElseThrow();
+		assertThat(approvedApplication.getStatus()).isEqualTo(TeamApplicationStatus.APPROVED);
+		assertThat(teamMemberRepository.existsByTeamIdAndUserId(team.getId(), applicant.getId())).isTrue();
+	}
+
+	@Test
+	void rejectApplication_returnsRejectedStatusWhenRequesterIsOwner() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
+		Team team = teamRepository.save(Team.create("Futsal Team", null, "FUTSAL", owner));
+		TeamApplication application = teamApplicationRepository.save(
+			TeamApplication.create(team, applicant, "가입하고 싶습니다.")
+		);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/team-applications/{applicationId}/reject", application.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.applicationId").value(application.getId()))
+			.andExpect(jsonPath("$.data.status").value("REJECTED"));
+
+		TeamApplication rejectedApplication = teamApplicationRepository.findById(application.getId()).orElseThrow();
+		assertThat(rejectedApplication.getStatus()).isEqualTo(TeamApplicationStatus.REJECTED);
+		assertThat(teamMemberRepository.existsByTeamIdAndUserId(team.getId(), applicant.getId())).isFalse();
+	}
+
+	@Test
+	void approveApplication_failsWhenRequesterIsNotOwner() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
+		User outsider = userRepository.save(User.create("outsider@test.com", "encoded-password", "outsider"));
+		Team team = teamRepository.save(Team.create("Futsal Team", null, "FUTSAL", owner));
+		TeamApplication application = teamApplicationRepository.save(
+			TeamApplication.create(team, applicant, "가입하고 싶습니다.")
+		);
+		String accessToken = jwtTokenProvider.createAccessToken(outsider.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/team-applications/{applicationId}/approve", application.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("T002"));
+	}
+
+	@Test
+	void rejectApplication_failsWhenRequesterIsNotOwner() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
+		User outsider = userRepository.save(User.create("outsider@test.com", "encoded-password", "outsider"));
+		Team team = teamRepository.save(Team.create("Futsal Team", null, "FUTSAL", owner));
+		TeamApplication application = teamApplicationRepository.save(
+			TeamApplication.create(team, applicant, "가입하고 싶습니다.")
+		);
+		String accessToken = jwtTokenProvider.createAccessToken(outsider.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/team-applications/{applicationId}/reject", application.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("T002"));
+	}
+
+	@Test
+	void approveApplication_failsWhenApplicationAlreadyProcessed() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
+		Team team = teamRepository.save(Team.create("Futsal Team", null, "FUTSAL", owner));
+		TeamApplication application = TeamApplication.create(team, applicant, "가입하고 싶습니다.");
+		application.approve();
+		TeamApplication savedApplication = teamApplicationRepository.save(application);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/team-applications/{applicationId}/approve", savedApplication.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value("TA003"));
+	}
+
+	@Test
+	void approveApplication_failsWhenApplicationNotFound() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/team-applications/{applicationId}/approve", 999L)
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("TA001"));
+	}
+
+	@Test
+	void approveApplication_failsWhenApplicantAlreadyBelongsToSameCategory() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		User existingOwner = userRepository.save(User.create("existing-owner@test.com", "encoded-password", "existingOwner"));
+		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
+		Team team = teamRepository.save(Team.create("Futsal Team", null, "FUTSAL", owner));
+		Team existingTeam = teamRepository.save(Team.create("Existing Futsal Team", null, "FUTSAL", existingOwner));
+		userCategoryMembershipRepository.saveAndFlush(
+			UserCategoryMembership.create(applicant, "FUTSAL", existingTeam)
+		);
+		TeamApplication application = teamApplicationRepository.save(
+			TeamApplication.create(team, applicant, "message")
+		);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/team-applications/{applicationId}/approve", application.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value("T007"));
+	}
+
+	@Test
+	void approveApplication_failsWhenDuplicateTeamMemberExists() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
+		Team team = teamRepository.save(Team.create("Futsal Team", null, "FUTSAL", owner));
+		teamMemberRepository.saveAndFlush(TeamMember.createMember(team, applicant));
+		TeamApplication application = teamApplicationRepository.save(
+			TeamApplication.create(team, applicant, "message")
+		);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/team-applications/{applicationId}/approve", application.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value("T004"));
+	}
+
+	@Test
+	void approveApplication_cancelsOtherPendingApplicationsInSameCategory() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		User otherOwner = userRepository.save(User.create("other-owner@test.com", "encoded-password", "otherOwner"));
+		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
+		Team team = teamRepository.save(Team.create("Futsal Team", null, "FUTSAL", owner));
+		Team otherSameCategoryTeam = teamRepository.save(Team.create("Other Futsal Team", null, "FUTSAL", otherOwner));
+		TeamApplication application = teamApplicationRepository.save(
+			TeamApplication.create(team, applicant, "first")
+		);
+		TeamApplication otherPendingApplication = teamApplicationRepository.save(
+			TeamApplication.create(otherSameCategoryTeam, applicant, "second")
+		);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/team-applications/{applicationId}/approve", application.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.status").value("APPROVED"));
+
+		TeamApplication approvedApplication = teamApplicationRepository.findById(application.getId()).orElseThrow();
+		TeamApplication canceledApplication = teamApplicationRepository.findById(otherPendingApplication.getId()).orElseThrow();
+		assertThat(approvedApplication.getStatus()).isEqualTo(TeamApplicationStatus.APPROVED);
+		assertThat(canceledApplication.getStatus()).isEqualTo(TeamApplicationStatus.CANCELED);
+		assertThat(canceledApplication.isActive()).isFalse();
+	}
+
+	@Test
+	void approveApplication_doesNotCancelPendingApplicationsInDifferentCategory() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		User otherOwner = userRepository.save(User.create("other-owner@test.com", "encoded-password", "otherOwner"));
+		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
+		Team team = teamRepository.save(Team.create("Futsal Team", null, "FUTSAL", owner));
+		Team differentCategoryTeam = teamRepository.save(Team.create("Baseball Team", null, "BASEBALL", otherOwner));
+		TeamApplication application = teamApplicationRepository.save(
+			TeamApplication.create(team, applicant, "first")
+		);
+		TeamApplication differentCategoryApplication = teamApplicationRepository.save(
+			TeamApplication.create(differentCategoryTeam, applicant, "baseball")
+		);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/team-applications/{applicationId}/approve", application.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.status").value("APPROVED"));
+
+		TeamApplication pendingApplication = teamApplicationRepository.findById(differentCategoryApplication.getId()).orElseThrow();
+		assertThat(pendingApplication.getStatus()).isEqualTo(TeamApplicationStatus.PENDING);
+		assertThat(pendingApplication.isActive()).isTrue();
+	}
+
+	@Test
+	void rejectApplication_failsWhenApplicationAlreadyApproved() throws Exception {
+		assertRejectFailsWhenApplicationAlreadyProcessed(TeamApplicationStatus.APPROVED);
+	}
+
+	@Test
+	void rejectApplication_failsWhenApplicationAlreadyRejected() throws Exception {
+		assertRejectFailsWhenApplicationAlreadyProcessed(TeamApplicationStatus.REJECTED);
+	}
+
+	@Test
+	void rejectApplication_failsWhenApplicationAlreadyCanceled() throws Exception {
+		assertRejectFailsWhenApplicationAlreadyProcessed(TeamApplicationStatus.CANCELED);
+	}
+
+	@Test
+	void rejectApplication_failsWhenApplicationNotFound() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/team-applications/{applicationId}/reject", 999L)
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("TA001"));
+	}
+
+	private void assertRejectFailsWhenApplicationAlreadyProcessed(TeamApplicationStatus status) throws Exception {
+		User owner = userRepository.save(User.create("owner-" + status + "@test.com", "encoded-password", "owner"));
+		User applicant = userRepository.save(User.create("applicant-" + status + "@test.com", "encoded-password", "applicant"));
+		Team team = teamRepository.save(Team.create("Futsal Team " + status, null, "FUTSAL", owner));
+		TeamApplication application = TeamApplication.create(team, applicant, "message");
+		switch (status) {
+			case APPROVED -> application.approve();
+			case REJECTED -> application.reject();
+			case CANCELED -> application.cancel();
+			default -> throw new IllegalArgumentException("Unsupported status: " + status);
+		}
+		TeamApplication savedApplication = teamApplicationRepository.save(application);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/team-applications/{applicationId}/reject", savedApplication.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value("TA003"));
 	}
 }

--- a/src/test/java/com/neomango/team/entity/TeamApplicationTest.java
+++ b/src/test/java/com/neomango/team/entity/TeamApplicationTest.java
@@ -1,0 +1,85 @@
+package com.neomango.team.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.neomango.team.exception.ApplicationAlreadyProcessedException;
+import com.neomango.user.entity.User;
+
+class TeamApplicationTest {
+
+	@Test
+	void createInitializesPendingAndActive() {
+		TeamApplication application = application();
+
+		assertThat(application.getStatus()).isEqualTo(TeamApplicationStatus.PENDING);
+		assertThat(application.isActive()).isTrue();
+	}
+
+	@Test
+	void approveChangesStatusAndDeactivatesApplication() {
+		TeamApplication application = application();
+
+		application.approve();
+
+		assertThat(application.getStatus()).isEqualTo(TeamApplicationStatus.APPROVED);
+		assertThat(application.isActive()).isFalse();
+	}
+
+	@Test
+	void rejectChangesStatusAndDeactivatesApplication() {
+		TeamApplication application = application();
+
+		application.reject();
+
+		assertThat(application.getStatus()).isEqualTo(TeamApplicationStatus.REJECTED);
+		assertThat(application.isActive()).isFalse();
+	}
+
+	@Test
+	void cancelChangesStatusAndDeactivatesApplication() {
+		TeamApplication application = application();
+
+		application.cancel();
+
+		assertThat(application.getStatus()).isEqualTo(TeamApplicationStatus.CANCELED);
+		assertThat(application.isActive()).isFalse();
+		assertThat(application.getCanceledAt()).isNotNull();
+	}
+
+	@Test
+	void approveRejectAndCancelFailWhenApplicationIsNotPending() {
+		TeamApplication approved = application();
+		approved.approve();
+		TeamApplication rejected = application();
+		rejected.reject();
+		TeamApplication canceled = application();
+		canceled.cancel();
+
+		assertAlreadyProcessed(approved::approve);
+		assertAlreadyProcessed(rejected::reject);
+		assertAlreadyProcessed(canceled::cancel);
+	}
+
+	@Test
+	void validatePendingFailsWhenApplicationIsAlreadyProcessed() {
+		TeamApplication application = application();
+		application.approve();
+
+		assertAlreadyProcessed(application::validatePending);
+	}
+
+	private void assertAlreadyProcessed(Runnable runnable) {
+		assertThatThrownBy(runnable::run)
+			.isInstanceOf(ApplicationAlreadyProcessedException.class);
+	}
+
+	private TeamApplication application() {
+		User owner = User.create("owner@test.com", "encoded-password", "owner");
+		User applicant = User.create("applicant@test.com", "encoded-password", "applicant");
+		Team team = Team.create("Team", null, "FUTSAL", owner);
+		return TeamApplication.create(team, applicant, "message");
+	}
+}

--- a/src/test/java/com/neomango/team/repository/TeamRepositoryTest.java
+++ b/src/test/java/com/neomango/team/repository/TeamRepositoryTest.java
@@ -21,6 +21,7 @@ import com.neomango.team.entity.TeamMember;
 import com.neomango.team.entity.TeamMemberRole;
 import com.neomango.team.entity.TeamMemberStatus;
 import com.neomango.team.entity.TeamStatus;
+import com.neomango.team.entity.UserCategoryMembership;
 import com.neomango.user.entity.User;
 import com.neomango.user.repository.UserRepository;
 
@@ -40,6 +41,9 @@ class TeamRepositoryTest {
 
 	@Autowired
 	private TeamApplicationRepository teamApplicationRepository;
+
+	@Autowired
+	private UserCategoryMembershipRepository userCategoryMembershipRepository;
 
 	@Autowired
 	private UserRepository userRepository;
@@ -119,6 +123,24 @@ class TeamRepositoryTest {
 
 		assertThatThrownBy(() -> {
 			teamMemberRepository.saveAndFlush(TeamMember.createMember(team, owner));
+		}).isInstanceOf(DataIntegrityViolationException.class);
+	}
+
+	@Test
+	@DisplayName("fail to save duplicate UserCategoryMembership for same user and category")
+	void duplicateUserCategoryMembershipFails() {
+		User owner = saveUser("owner-category@test.com", "ownerCategory");
+		User applicant = saveUser("category-applicant@test.com", "categoryApplicant");
+		Team team1 = teamRepository.saveAndFlush(Team.create("Futsal Team 1", null, "FUTSAL", owner));
+		Team team2 = teamRepository.saveAndFlush(Team.create("Futsal Team 2", null, "FUTSAL", owner));
+		userCategoryMembershipRepository.saveAndFlush(
+			UserCategoryMembership.create(applicant, "FUTSAL", team1)
+		);
+
+		assertThatThrownBy(() -> {
+			userCategoryMembershipRepository.saveAndFlush(
+				UserCategoryMembership.create(applicant, "FUTSAL", team2)
+			);
 		}).isInstanceOf(DataIntegrityViolationException.class);
 	}
 
@@ -216,6 +238,12 @@ class TeamRepositoryTest {
 		TeamApplication applicationWithTeam = teamApplicationRepository.findByIdWithTeam(application.getId())
 			.orElseThrow();
 		assertThat(Hibernate.isInitialized(applicationWithTeam.getTeam())).isTrue();
+
+		entityManager.clear();
+		TeamApplication lockedApplication = teamApplicationRepository.findByIdForUpdate(application.getId())
+			.orElseThrow();
+		assertThat(Hibernate.isInitialized(lockedApplication.getTeam())).isTrue();
+		assertThat(Hibernate.isInitialized(lockedApplication.getApplicant())).isTrue();
 
 		entityManager.clear();
 		TeamApplication applicantApplication = teamApplicationRepository

--- a/src/test/java/com/neomango/team/service/TeamApplicationConcurrencyTest.java
+++ b/src/test/java/com/neomango/team/service/TeamApplicationConcurrencyTest.java
@@ -1,0 +1,203 @@
+package com.neomango.team.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.neomango.team.dto.TeamApplicationResponse;
+import com.neomango.team.entity.Team;
+import com.neomango.team.entity.TeamApplication;
+import com.neomango.team.entity.TeamApplicationStatus;
+import com.neomango.team.repository.TeamApplicationRepository;
+import com.neomango.team.repository.TeamMemberRepository;
+import com.neomango.team.repository.TeamRepository;
+import com.neomango.team.repository.UserCategoryMembershipRepository;
+import com.neomango.user.entity.User;
+import com.neomango.user.repository.UserRepository;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class TeamApplicationConcurrencyTest {
+
+	@Autowired
+	private TeamApplicationService teamApplicationService;
+
+	@Autowired
+	private TeamApplicationRepository teamApplicationRepository;
+
+	@Autowired
+	private TeamMemberRepository teamMemberRepository;
+
+	@Autowired
+	private UserCategoryMembershipRepository userCategoryMembershipRepository;
+
+	@Autowired
+	private TeamRepository teamRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@BeforeEach
+	void setUp() {
+		cleanUp();
+	}
+
+	@AfterEach
+	void tearDown() {
+		cleanUp();
+	}
+
+	private void cleanUp() {
+		teamApplicationRepository.deleteAll();
+		userCategoryMembershipRepository.deleteAll();
+		teamMemberRepository.deleteAll();
+		teamRepository.deleteAll();
+		userRepository.deleteAll();
+	}
+
+	@Test
+	void approveApplication_allowsOnlyOneSuccessWhenSameApplicationIsApprovedConcurrently() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
+		Team team = teamRepository.save(Team.create("Futsal Team", null, "FUTSAL", owner));
+		TeamApplication application = teamApplicationRepository.save(
+			TeamApplication.create(team, applicant, "message")
+		);
+
+		ConcurrentResult result = runConcurrently(5,
+			() -> teamApplicationService.approveApplication(application.getId(), owner.getId()));
+
+		TeamApplication approvedApplication = teamApplicationRepository.findById(application.getId()).orElseThrow();
+		assertThat(result.successCount()).isEqualTo(1);
+		assertThat(result.failureCount()).isEqualTo(4);
+		assertThat(approvedApplication.getStatus()).isEqualTo(TeamApplicationStatus.APPROVED);
+		assertThat(teamMemberRepository.countByTeamIdAndUserId(team.getId(), applicant.getId())).isEqualTo(1);
+	}
+
+	@Test
+	void processApplication_allowsOnlyOneSuccessWhenApproveAndRejectRunConcurrently() throws Exception {
+		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
+		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
+		Team team = teamRepository.save(Team.create("Futsal Team", null, "FUTSAL", owner));
+		TeamApplication application = teamApplicationRepository.save(
+			TeamApplication.create(team, applicant, "message")
+		);
+
+		ConcurrentResult result = runConcurrently(List.of(
+			() -> teamApplicationService.approveApplication(application.getId(), owner.getId()),
+			() -> teamApplicationService.rejectApplication(application.getId(), owner.getId())
+		));
+
+		TeamApplication processedApplication = teamApplicationRepository.findById(application.getId()).orElseThrow();
+		long memberCount = teamMemberRepository.countByTeamIdAndUserId(team.getId(), applicant.getId());
+
+		assertThat(result.successCount()).isEqualTo(1);
+		assertThat(result.failureCount()).isEqualTo(1);
+		assertThat(processedApplication.getStatus())
+			.isIn(TeamApplicationStatus.APPROVED, TeamApplicationStatus.REJECTED);
+		if (processedApplication.getStatus() == TeamApplicationStatus.APPROVED) {
+			assertThat(memberCount).isEqualTo(1);
+		}
+		else {
+			assertThat(memberCount).isZero();
+		}
+	}
+
+	@Test
+	void approveApplication_allowsOnlyOneSameCategoryApplicationWhenDifferentTeamsAreApprovedConcurrently() throws Exception {
+		User owner1 = userRepository.save(User.create("owner1@test.com", "encoded-password", "owner1"));
+		User owner2 = userRepository.save(User.create("owner2@test.com", "encoded-password", "owner2"));
+		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
+		Team team1 = teamRepository.save(Team.create("Futsal Team 1", null, "FUTSAL", owner1));
+		Team team2 = teamRepository.save(Team.create("Futsal Team 2", null, "FUTSAL", owner2));
+		TeamApplication application1 = teamApplicationRepository.save(
+			TeamApplication.create(team1, applicant, "first")
+		);
+		TeamApplication application2 = teamApplicationRepository.save(
+			TeamApplication.create(team2, applicant, "second")
+		);
+
+		ConcurrentResult result = runConcurrently(List.of(
+			() -> teamApplicationService.approveApplication(application1.getId(), owner1.getId()),
+			() -> teamApplicationService.approveApplication(application2.getId(), owner2.getId())
+		));
+
+		TeamApplication processedApplication1 = teamApplicationRepository.findById(application1.getId()).orElseThrow();
+		TeamApplication processedApplication2 = teamApplicationRepository.findById(application2.getId()).orElseThrow();
+		long team1MemberCount = teamMemberRepository.countByTeamIdAndUserId(team1.getId(), applicant.getId());
+		long team2MemberCount = teamMemberRepository.countByTeamIdAndUserId(team2.getId(), applicant.getId());
+		long approvedCount = List.of(processedApplication1, processedApplication2)
+			.stream()
+			.filter(application -> application.getStatus() == TeamApplicationStatus.APPROVED)
+			.count();
+
+		assertThat(result.successCount()).isEqualTo(1);
+		assertThat(result.failureCount()).isEqualTo(1);
+		assertThat(approvedCount).isEqualTo(result.successCount());
+		assertThat(team1MemberCount + team2MemberCount).isEqualTo(result.successCount());
+		assertThat(userCategoryMembershipRepository.countByUserIdAndCategory(applicant.getId(), "FUTSAL"))
+			.isEqualTo(1);
+	}
+
+	private ConcurrentResult runConcurrently(int taskCount, Callable<TeamApplicationResponse> task) throws Exception {
+		List<Callable<TeamApplicationResponse>> tasks = new ArrayList<>();
+		for (int i = 0; i < taskCount; i++) {
+			tasks.add(task);
+		}
+		return runConcurrently(tasks);
+	}
+
+	private ConcurrentResult runConcurrently(List<Callable<TeamApplicationResponse>> tasks) throws Exception {
+		ExecutorService executorService = Executors.newFixedThreadPool(tasks.size());
+		CountDownLatch ready = new CountDownLatch(tasks.size());
+		CountDownLatch start = new CountDownLatch(1);
+		Queue<TeamApplicationResponse> successes = new ConcurrentLinkedQueue<>();
+		Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
+
+		try {
+			List<Future<Object>> futures = tasks.stream()
+				.map(task -> executorService.submit(() -> {
+					ready.countDown();
+					start.await();
+					try {
+						successes.add(task.call());
+					}
+					catch (Throwable throwable) {
+						failures.add(throwable);
+					}
+					return null;
+				}))
+				.toList();
+
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			for (Future<Object> future : futures) {
+				future.get(10, TimeUnit.SECONDS);
+			}
+		}
+		finally {
+			executorService.shutdownNow();
+		}
+
+		return new ConcurrentResult(successes.size(), failures.size(), List.copyOf(failures));
+	}
+
+	private record ConcurrentResult(int successCount, int failureCount, List<Throwable> failures) {
+	}
+}

--- a/src/test/java/com/neomango/team/service/TeamApplicationServiceTest.java
+++ b/src/test/java/com/neomango/team/service/TeamApplicationServiceTest.java
@@ -3,11 +3,13 @@ package com.neomango.team.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -25,11 +27,15 @@ import com.neomango.team.dto.TeamApplicationResponse;
 import com.neomango.team.entity.Team;
 import com.neomango.team.entity.TeamApplication;
 import com.neomango.team.entity.TeamApplicationStatus;
+import com.neomango.team.entity.TeamMember;
+import com.neomango.team.entity.TeamMemberRole;
 import com.neomango.team.entity.TeamMemberStatus;
 import com.neomango.team.entity.TeamStatus;
+import com.neomango.team.exception.ApplicationAlreadyProcessedException;
 import com.neomango.team.repository.TeamApplicationRepository;
 import com.neomango.team.repository.TeamMemberRepository;
 import com.neomango.team.repository.TeamRepository;
+import com.neomango.team.repository.UserCategoryMembershipRepository;
 import com.neomango.user.entity.User;
 import com.neomango.user.repository.UserRepository;
 
@@ -48,6 +54,9 @@ class TeamApplicationServiceTest {
 
 	@Mock
 	private TeamMemberRepository teamMemberRepository;
+
+	@Mock
+	private UserCategoryMembershipRepository userCategoryMembershipRepository;
 
 	@Mock
 	private UserRepository userRepository;
@@ -330,6 +339,105 @@ class TeamApplicationServiceTest {
 		assertThat(response.status()).isEqualTo(TeamApplicationStatus.CANCELED);
 	}
 
+	@Test
+	void approveApplicationCreatesTeamMemberAndApprovesPendingApplication() {
+		User owner = user(1L, "owner@test.com", "owner");
+		User applicant = user(APPLICANT_ID, "applicant@test.com", "applicant");
+		Team team = team(TEAM_ID, owner, "FUTSAL");
+		TeamApplication application = application(100L, team, applicant);
+		when(teamApplicationRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(application));
+		when(teamMemberRepository.findByTeamIdAndRole(TEAM_ID, TeamMemberRole.OWNER))
+			.thenReturn(Optional.of(team.getMembers().get(0)));
+		when(teamMemberRepository.existsByTeamIdAndUserId(TEAM_ID, APPLICANT_ID)).thenReturn(false);
+		when(teamMemberRepository.existsByTeamIdAndUserIdAndStatus(TEAM_ID, APPLICANT_ID, TeamMemberStatus.ACTIVE))
+			.thenReturn(false);
+		when(teamMemberRepository.existsActiveMemberByUserIdAndTeamCategory(APPLICANT_ID, "FUTSAL"))
+			.thenReturn(false);
+		when(teamApplicationRepository.findOtherPendingApplicationsInSameCategory(100L, APPLICANT_ID, "FUTSAL"))
+			.thenReturn(List.of());
+
+		TeamApplicationResponse response = teamApplicationService.approveApplication(100L, owner.getId());
+
+		assertThat(response.status()).isEqualTo(TeamApplicationStatus.APPROVED);
+		assertThat(application.getStatus()).isEqualTo(TeamApplicationStatus.APPROVED);
+		ArgumentCaptor<TeamMember> captor = ArgumentCaptor.forClass(TeamMember.class);
+		verify(teamMemberRepository).save(captor.capture());
+		assertThat(captor.getValue().getTeam()).isSameAs(team);
+		assertThat(captor.getValue().getUser()).isSameAs(applicant);
+		assertThat(captor.getValue().getRole()).isEqualTo(TeamMemberRole.MEMBER);
+	}
+
+	@Test
+	void rejectApplicationRejectsPendingApplicationWithoutCreatingTeamMember() {
+		User owner = user(1L, "owner@test.com", "owner");
+		User applicant = user(APPLICANT_ID, "applicant@test.com", "applicant");
+		Team team = team(TEAM_ID, owner, "FUTSAL");
+		TeamApplication application = application(100L, team, applicant);
+		when(teamApplicationRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(application));
+		when(teamMemberRepository.findByTeamIdAndRole(TEAM_ID, TeamMemberRole.OWNER))
+			.thenReturn(Optional.of(team.getMembers().get(0)));
+
+		TeamApplicationResponse response = teamApplicationService.rejectApplication(100L, owner.getId());
+
+		assertThat(response.status()).isEqualTo(TeamApplicationStatus.REJECTED);
+		assertThat(application.getStatus()).isEqualTo(TeamApplicationStatus.REJECTED);
+		verify(teamMemberRepository, never()).save(any(TeamMember.class));
+	}
+
+	@Test
+	void approveAndRejectApplicationFailWhenRequesterIsNotOwner() {
+		User owner = user(1L, "owner@test.com", "owner");
+		User applicant = user(APPLICANT_ID, "applicant@test.com", "applicant");
+		Team team = team(TEAM_ID, owner, "FUTSAL");
+		when(teamApplicationRepository.findByIdForUpdate(100L))
+			.thenReturn(Optional.of(application(100L, team, applicant)))
+			.thenReturn(Optional.of(application(101L, team, applicant)));
+		when(teamMemberRepository.findByTeamIdAndRole(TEAM_ID, TeamMemberRole.OWNER))
+			.thenReturn(Optional.of(team.getMembers().get(0)));
+
+		assertBusinessException(
+			() -> teamApplicationService.approveApplication(100L, 999L),
+			ErrorCode.TEAM_OWNER_REQUIRED
+		);
+		assertBusinessException(
+			() -> teamApplicationService.rejectApplication(100L, 999L),
+			ErrorCode.TEAM_OWNER_REQUIRED
+		);
+
+		verify(teamMemberRepository, never()).save(any(TeamMember.class));
+	}
+
+	@Test
+	void approveAndRejectApplicationFailWhenApplicationIsAlreadyProcessed() {
+		assertProcessFailsWhenApplicationStatusIs(TeamApplicationStatus.APPROVED);
+		assertProcessFailsWhenApplicationStatusIs(TeamApplicationStatus.REJECTED);
+		assertProcessFailsWhenApplicationStatusIs(TeamApplicationStatus.CANCELED);
+	}
+
+	@Test
+	void approveApplicationCancelsOtherPendingApplicationsInSameCategory() {
+		User owner = user(1L, "owner@test.com", "owner");
+		User applicant = user(APPLICANT_ID, "applicant@test.com", "applicant");
+		Team team = team(TEAM_ID, owner, "FUTSAL");
+		TeamApplication application = application(100L, team, applicant);
+		TeamApplication otherApplication = application(101L, team(11L, user(3L, "other-owner@test.com", "other"), "FUTSAL"), applicant);
+		when(teamApplicationRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(application));
+		when(teamMemberRepository.findByTeamIdAndRole(TEAM_ID, TeamMemberRole.OWNER))
+			.thenReturn(Optional.of(team.getMembers().get(0)));
+		when(teamMemberRepository.existsByTeamIdAndUserId(TEAM_ID, APPLICANT_ID)).thenReturn(false);
+		when(teamMemberRepository.existsByTeamIdAndUserIdAndStatus(TEAM_ID, APPLICANT_ID, TeamMemberStatus.ACTIVE))
+			.thenReturn(false);
+		when(teamMemberRepository.existsActiveMemberByUserIdAndTeamCategory(APPLICANT_ID, "FUTSAL"))
+			.thenReturn(false);
+		when(teamApplicationRepository.findOtherPendingApplicationsInSameCategory(100L, APPLICANT_ID, "FUTSAL"))
+			.thenReturn(List.of(otherApplication));
+
+		teamApplicationService.approveApplication(100L, owner.getId());
+
+		assertThat(application.getStatus()).isEqualTo(TeamApplicationStatus.APPROVED);
+		assertThat(otherApplication.getStatus()).isEqualTo(TeamApplicationStatus.CANCELED);
+	}
+
 	private void createApplicationSucceedsWhenNoPendingApplicationExists() {
 		User applicant = user(APPLICANT_ID, "applicant@test.com", "applicant");
 		Team team = team(TEAM_ID, user(1L, "owner@test.com", "owner"), "FUTSAL");
@@ -383,6 +491,25 @@ class TeamApplicationServiceTest {
 			() -> teamApplicationService.cancelApplication(100L, APPLICANT_ID),
 			ErrorCode.ONLY_PENDING_TEAM_APPLICATION_CANCELABLE
 		);
+	}
+
+	private void assertProcessFailsWhenApplicationStatusIs(TeamApplicationStatus status) {
+		User applicant = user(APPLICANT_ID, "applicant@test.com", "applicant");
+		Team team = team(TEAM_ID, user(1L, "owner@test.com", "owner"), "FUTSAL");
+		TeamApplication application = application(100L, team, applicant);
+		switch (status) {
+			case APPROVED -> application.approve();
+			case REJECTED -> application.reject();
+			case CANCELED -> application.cancel();
+			default -> throw new IllegalArgumentException("Unsupported status: " + status);
+		}
+		when(teamApplicationRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(application));
+
+		assertThatThrownBy(() -> teamApplicationService.approveApplication(100L, 1L))
+			.isInstanceOf(ApplicationAlreadyProcessedException.class);
+		when(teamApplicationRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(application));
+		assertThatThrownBy(() -> teamApplicationService.rejectApplication(100L, 1L))
+			.isInstanceOf(ApplicationAlreadyProcessedException.class);
 	}
 
 	private TeamApplicationCreateRequest request() {


### PR DESCRIPTION
## 📝 개요
- **작업 유형**: 기능 추가 / 문서 수정 / 테스트 추가
- **관련 이슈**: #7 
- **요약**: 팀 가입 신청 승인/거절 API와 상태 정합성 처리를 구현했음.

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🚀 주요 변경 사항
- **도메인 변경**: TeamApplication 상태 전이를 Entity 메서드로 관리하도록 변경했음.
- **도메인 변경**: UserCategoryMembership을 추가해 같은 사용자 + 같은 카테고리 중복 소속을 DB unique 제약으로 방어했음.
- **비즈니스 로직**: approve/reject 처리 시 TeamApplication PESSIMISTIC_WRITE 락을 사용하도록 구현했음.
- **비즈니스 로직**: 승인 시 UserCategoryMembership 생성, TeamMember 생성, 신청 APPROVED 변경, 같은 카테고리 다른 PENDING 신청 CANCELED 처리를 하나의 트랜잭션에서 수행했음.
- **API**: POST /api/team-applications/{applicationId}/approve, POST /api/team-applications/{applicationId}/reject를 추가했음.
- **정책**: 팀 정원 정책은 제거된 상태를 유지하고 currentMemberCount/maxMemberCount 기반 로직을 사용하지 않도록 문서화했음.
