### PR TITLE
feat(team): 팀원 관리 기능 구현

### DIFF
--- a/src/main/java/com/neomango/global/exception/ErrorCode.java
+++ b/src/main/java/com/neomango/global/exception/ErrorCode.java
@@ -25,6 +25,16 @@ public enum ErrorCode {
 	DUPLICATE_TEAM_MEMBER(HttpStatus.CONFLICT, "T004", "이미 존재하는 팀 멤버입니다."),
 	TEAM_CLOSED(HttpStatus.CONFLICT, "T006", "마감된 팀입니다."),
 	ALREADY_CATEGORY_TEAM_MEMBER(HttpStatus.CONFLICT, "T007", "이미 해당 카테고리의 팀에 소속되었습니다."),
+	TEAM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "T008", "해당 팀의 멤버가 아닙니다."),
+	CANNOT_KICK_SELF(HttpStatus.CONFLICT, "T009", "자기 자신을 강퇴할 수 없습니다."),
+	CANNOT_LEAVE_OWNER_WITHOUT_DELEGATION(
+		HttpStatus.CONFLICT,
+		"T010",
+		"현재 탈퇴하려는 팀의 주장입니다. 다음 주장을 선택하고 탈퇴하여 주십시오."
+	),
+	INVALID_OWNER_DELEGATION_TARGET(HttpStatus.CONFLICT, "T011", "위임 대상은 같은 팀의 활성 멤버여야 합니다."),
+	CANNOT_KICK_OWNER(HttpStatus.CONFLICT, "T012", "팀 주장은 강퇴할 수 없습니다."),
+	TEAM_OWNER_INVARIANT_VIOLATED(HttpStatus.CONFLICT, "T013", "활성 팀 주장은 반드시 한 명이어야 합니다."),
 	TEAM_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "TA001", "존재하지 않는 가입 신청입니다."),
 	DUPLICATE_PENDING_TEAM_APPLICATION(HttpStatus.CONFLICT, "TA002", "이미 가입 신청한 팀입니다."),
 	INVALID_TEAM_APPLICATION_STATUS(HttpStatus.CONFLICT, "TA003", "처리할 수 없는 가입 신청 상태입니다."),

--- a/src/main/java/com/neomango/team/controller/TeamController.java
+++ b/src/main/java/com/neomango/team/controller/TeamController.java
@@ -29,9 +29,12 @@ import com.neomango.team.dto.TeamApplicationOwnerResponse;
 import com.neomango.team.dto.TeamApplicationResponse;
 import com.neomango.team.dto.TeamCreateRequest;
 import com.neomango.team.dto.TeamDetailResponse;
+import com.neomango.team.dto.TeamMemberListResponse;
+import com.neomango.team.dto.OwnerDelegationRequest;
 import com.neomango.team.dto.TeamResponse;
 import com.neomango.team.dto.TeamSummaryResponse;
 import com.neomango.team.service.TeamApplicationService;
+import com.neomango.team.service.TeamMemberService;
 import com.neomango.team.service.TeamService;
 
 import jakarta.validation.Valid;
@@ -44,6 +47,7 @@ public class TeamController {
 
 	private final TeamService teamService;
 	private final TeamApplicationService teamApplicationService;
+	private final TeamMemberService teamMemberService;
 
 	@GetMapping
 	public ApiResponse<Page<TeamSummaryResponse>> getTeams(
@@ -60,6 +64,59 @@ public class TeamController {
 	@GetMapping("/{teamId}")
 	public ApiResponse<TeamDetailResponse> getTeamDetail(@PathVariable Long teamId) {
 		return ApiResponse.success(teamService.getTeamDetail(teamId));
+	}
+
+	@GetMapping("/{teamId}/members")
+	public ApiResponse<List<TeamMemberListResponse>> getTeamMembers(
+		@AuthenticationPrincipal AuthenticatedUser currentUser,
+		@PathVariable Long teamId
+	) {
+		if (currentUser == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		return ApiResponse.success(teamMemberService.getActiveTeamMembers(teamId));
+	}
+
+	@PostMapping("/{teamId}/members/me/leave")
+	public ApiResponse<Void> leaveTeam(
+		@AuthenticationPrincipal AuthenticatedUser currentUser,
+		@PathVariable Long teamId
+	) {
+		if (currentUser == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		teamMemberService.leaveTeam(teamId, currentUser.userId());
+		return ApiResponse.successWithoutData();
+	}
+
+	@PostMapping("/{teamId}/members/{teamMemberId}/kick")
+	public ApiResponse<Void> kickMember(
+		@AuthenticationPrincipal AuthenticatedUser currentUser,
+		@PathVariable Long teamId,
+		@PathVariable Long teamMemberId
+	) {
+		if (currentUser == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		teamMemberService.kickMember(teamId, teamMemberId, currentUser.userId());
+		return ApiResponse.successWithoutData();
+	}
+
+	@PostMapping("/{teamId}/owner/delegate")
+	public ApiResponse<Void> delegateOwner(
+		@AuthenticationPrincipal AuthenticatedUser currentUser,
+		@PathVariable Long teamId,
+		@Valid @RequestBody OwnerDelegationRequest request
+	) {
+		if (currentUser == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		teamMemberService.delegateOwner(teamId, currentUser.userId(), request.targetTeamMemberId());
+		return ApiResponse.successWithoutData();
 	}
 
 	@PostMapping

--- a/src/main/java/com/neomango/team/dto/OwnerDelegationRequest.java
+++ b/src/main/java/com/neomango/team/dto/OwnerDelegationRequest.java
@@ -1,0 +1,9 @@
+package com.neomango.team.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record OwnerDelegationRequest(
+	@NotNull
+	Long targetTeamMemberId
+) {
+}

--- a/src/main/java/com/neomango/team/dto/TeamMemberListResponse.java
+++ b/src/main/java/com/neomango/team/dto/TeamMemberListResponse.java
@@ -1,0 +1,26 @@
+package com.neomango.team.dto;
+
+import com.neomango.team.entity.TeamMember;
+import com.neomango.team.entity.TeamMemberRole;
+import com.neomango.team.entity.TeamMemberStatus;
+import com.neomango.user.entity.User;
+
+public record TeamMemberListResponse(
+	Long teamMemberId,
+	Long userId,
+	String nickname,
+	TeamMemberRole role,
+	TeamMemberStatus status
+) {
+
+	public static TeamMemberListResponse from(TeamMember teamMember) {
+		User user = teamMember.getUser();
+		return new TeamMemberListResponse(
+			teamMember.getId(),
+			user.getId(),
+			user.getNickname(),
+			teamMember.getRole(),
+			teamMember.getStatus()
+		);
+	}
+}

--- a/src/main/java/com/neomango/team/entity/TeamMember.java
+++ b/src/main/java/com/neomango/team/entity/TeamMember.java
@@ -2,6 +2,8 @@ package com.neomango.team.entity;
 
 import java.time.LocalDateTime;
 
+import com.neomango.team.exception.NotTeamMemberException;
+import com.neomango.team.exception.NotTeamOwnerException;
 import com.neomango.user.entity.User;
 
 import jakarta.persistence.Column;
@@ -66,5 +68,33 @@ public class TeamMember {
 
 	public static TeamMember createMember(Team team, User user) {
 		return new TeamMember(team, user, TeamMemberRole.MEMBER);
+	}
+
+	public boolean isActive() {
+		return this.status == TeamMemberStatus.ACTIVE;
+	}
+
+	public boolean isOwner() {
+		return this.role == TeamMemberRole.OWNER;
+	}
+
+	public void deactivate() {
+		this.status = TeamMemberStatus.INACTIVE;
+	}
+
+	public void changeRole(TeamMemberRole role) {
+		this.role = role;
+	}
+
+	public void validateActive() {
+		if (!isActive()) {
+			throw new NotTeamMemberException();
+		}
+	}
+
+	public void validateOwner() {
+		if (!isOwner()) {
+			throw new NotTeamOwnerException();
+		}
 	}
 }

--- a/src/main/java/com/neomango/team/entity/TeamMemberStatus.java
+++ b/src/main/java/com/neomango/team/entity/TeamMemberStatus.java
@@ -2,6 +2,5 @@ package com.neomango.team.entity;
 
 public enum TeamMemberStatus {
 	ACTIVE,
-	LEFT,
-	KICKED
+	INACTIVE
 }

--- a/src/main/java/com/neomango/team/exception/CannotKickOwnerException.java
+++ b/src/main/java/com/neomango/team/exception/CannotKickOwnerException.java
@@ -1,0 +1,11 @@
+package com.neomango.team.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class CannotKickOwnerException extends BusinessException {
+
+	public CannotKickOwnerException() {
+		super(ErrorCode.CANNOT_KICK_OWNER);
+	}
+}

--- a/src/main/java/com/neomango/team/exception/CannotKickSelfException.java
+++ b/src/main/java/com/neomango/team/exception/CannotKickSelfException.java
@@ -1,0 +1,11 @@
+package com.neomango.team.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class CannotKickSelfException extends BusinessException {
+
+	public CannotKickSelfException() {
+		super(ErrorCode.CANNOT_KICK_SELF);
+	}
+}

--- a/src/main/java/com/neomango/team/exception/CannotLeaveOwnerWithoutDelegationException.java
+++ b/src/main/java/com/neomango/team/exception/CannotLeaveOwnerWithoutDelegationException.java
@@ -1,0 +1,11 @@
+package com.neomango.team.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class CannotLeaveOwnerWithoutDelegationException extends BusinessException {
+
+	public CannotLeaveOwnerWithoutDelegationException() {
+		super(ErrorCode.CANNOT_LEAVE_OWNER_WITHOUT_DELEGATION);
+	}
+}

--- a/src/main/java/com/neomango/team/exception/InvalidOwnerDelegationTargetException.java
+++ b/src/main/java/com/neomango/team/exception/InvalidOwnerDelegationTargetException.java
@@ -1,0 +1,11 @@
+package com.neomango.team.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class InvalidOwnerDelegationTargetException extends BusinessException {
+
+	public InvalidOwnerDelegationTargetException() {
+		super(ErrorCode.INVALID_OWNER_DELEGATION_TARGET);
+	}
+}

--- a/src/main/java/com/neomango/team/exception/NotTeamMemberException.java
+++ b/src/main/java/com/neomango/team/exception/NotTeamMemberException.java
@@ -1,0 +1,11 @@
+package com.neomango.team.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class NotTeamMemberException extends BusinessException {
+
+	public NotTeamMemberException() {
+		super(ErrorCode.TEAM_MEMBER_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/neomango/team/exception/TeamOwnerInvariantViolationException.java
+++ b/src/main/java/com/neomango/team/exception/TeamOwnerInvariantViolationException.java
@@ -1,0 +1,11 @@
+package com.neomango.team.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class TeamOwnerInvariantViolationException extends BusinessException {
+
+	public TeamOwnerInvariantViolationException() {
+		super(ErrorCode.TEAM_OWNER_INVARIANT_VIOLATED);
+	}
+}

--- a/src/main/java/com/neomango/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/neomango/team/repository/TeamMemberRepository.java
@@ -21,6 +21,7 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 		join fetch teamMember.user
 		where teamMember.team.id in :teamIds
 			and teamMember.role = com.neomango.team.entity.TeamMemberRole.OWNER
+			and teamMember.status = com.neomango.team.entity.TeamMemberStatus.ACTIVE
 		""")
 	List<TeamMember> findOwnersByTeamIds(@Param("teamIds") Collection<Long> teamIds);
 
@@ -29,17 +30,78 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 		from TeamMember teamMember
 		join fetch teamMember.user
 		where teamMember.team.id = :teamId
+			and teamMember.status = com.neomango.team.entity.TeamMemberStatus.ACTIVE
 		order by teamMember.joinedAt asc, teamMember.id asc
 		""")
 	List<TeamMember> findByTeamIdWithUser(@Param("teamId") Long teamId);
 
+	@Query("""
+		select teamMember
+		from TeamMember teamMember
+		join fetch teamMember.user
+		where teamMember.team.id = :teamId
+			and teamMember.status = com.neomango.team.entity.TeamMemberStatus.ACTIVE
+		order by teamMember.joinedAt asc, teamMember.id asc
+		""")
+	List<TeamMember> findActiveMembersByTeamId(@Param("teamId") Long teamId);
+
+	@Query("""
+		select teamMember
+		from TeamMember teamMember
+		join fetch teamMember.team
+		join fetch teamMember.user
+		where teamMember.team.id = :teamId
+			and teamMember.user.id = :userId
+			and teamMember.status = com.neomango.team.entity.TeamMemberStatus.ACTIVE
+		""")
+	Optional<TeamMember> findActiveMemberByTeamIdAndUserId(
+		@Param("teamId") Long teamId,
+		@Param("userId") Long userId
+	);
+
+	@Query("""
+		select teamMember
+		from TeamMember teamMember
+		join fetch teamMember.team
+		join fetch teamMember.user
+		where teamMember.id = :teamMemberId
+			and teamMember.status = com.neomango.team.entity.TeamMemberStatus.ACTIVE
+		""")
+	Optional<TeamMember> findActiveMemberById(@Param("teamMemberId") Long teamMemberId);
+
 	Optional<TeamMember> findByTeamIdAndRole(Long teamId, TeamMemberRole role);
+
+	@Query("""
+		select teamMember
+		from TeamMember teamMember
+		join fetch teamMember.user
+		where teamMember.team.id = :teamId
+			and teamMember.role = com.neomango.team.entity.TeamMemberRole.OWNER
+			and teamMember.status = com.neomango.team.entity.TeamMemberStatus.ACTIVE
+		""")
+	Optional<TeamMember> findActiveOwnerByTeamId(@Param("teamId") Long teamId);
 
 	boolean existsByTeamIdAndUserId(Long teamId, Long userId);
 
 	long countByTeamIdAndUserId(Long teamId, Long userId);
 
 	boolean existsByTeamIdAndUserIdAndStatus(Long teamId, Long userId, TeamMemberStatus status);
+
+	default boolean existsActiveMemberByTeamIdAndUserId(Long teamId, Long userId) {
+		return existsByTeamIdAndUserIdAndStatus(teamId, userId, TeamMemberStatus.ACTIVE);
+	}
+
+	long countByTeamIdAndStatus(Long teamId, TeamMemberStatus status);
+
+	default long countActiveMembersByTeamId(Long teamId) {
+		return countByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE);
+	}
+
+	long countByTeamIdAndRoleAndStatus(Long teamId, TeamMemberRole role, TeamMemberStatus status);
+
+	default long countActiveOwnersByTeamId(Long teamId) {
+		return countByTeamIdAndRoleAndStatus(teamId, TeamMemberRole.OWNER, TeamMemberStatus.ACTIVE);
+	}
 
 	@Query("""
 		select count(teamMember) > 0

--- a/src/main/java/com/neomango/team/repository/UserCategoryMembershipRepository.java
+++ b/src/main/java/com/neomango/team/repository/UserCategoryMembershipRepository.java
@@ -9,4 +9,6 @@ public interface UserCategoryMembershipRepository extends JpaRepository<UserCate
 	boolean existsByUserIdAndCategory(Long userId, String category);
 
 	long countByUserIdAndCategory(Long userId, String category);
+
+	long deleteByUserIdAndCategory(Long userId, String category);
 }

--- a/src/main/java/com/neomango/team/service/TeamApplicationService.java
+++ b/src/main/java/com/neomango/team/service/TeamApplicationService.java
@@ -254,7 +254,7 @@ public class TeamApplicationService {
 		TeamMember ownerMember = teamMemberRepository.findByTeamIdAndRole(team.getId(), TeamMemberRole.OWNER)
 			.orElseThrow(() -> new BusinessException(ErrorCode.TEAM_APPLICATION_LIST_OWNER_REQUIRED));
 
-		if (!ownerMember.getUser().getId().equals(requesterId) || ownerMember.getStatus() != TeamMemberStatus.ACTIVE) {
+		if (!ownerMember.getUser().getId().equals(requesterId) || !ownerMember.isActive()) {
 			throw new BusinessException(ErrorCode.TEAM_APPLICATION_LIST_OWNER_REQUIRED);
 		}
 	}
@@ -265,7 +265,7 @@ public class TeamApplicationService {
 
 		if (!ownerMember.getUser().getId().equals(loginUserId)
 			|| ownerMember.getRole() != TeamMemberRole.OWNER
-			|| ownerMember.getStatus() != TeamMemberStatus.ACTIVE) {
+			|| !ownerMember.isActive()) {
 			throw new NotTeamOwnerException();
 		}
 	}

--- a/src/main/java/com/neomango/team/service/TeamMemberService.java
+++ b/src/main/java/com/neomango/team/service/TeamMemberService.java
@@ -1,0 +1,142 @@
+package com.neomango.team.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+import com.neomango.team.dto.TeamMemberListResponse;
+import com.neomango.team.entity.Team;
+import com.neomango.team.entity.TeamApplication;
+import com.neomango.team.entity.TeamApplicationStatus;
+import com.neomango.team.entity.TeamMember;
+import com.neomango.team.entity.TeamMemberRole;
+import com.neomango.team.entity.TeamStatus;
+import com.neomango.team.exception.CannotKickOwnerException;
+import com.neomango.team.exception.CannotKickSelfException;
+import com.neomango.team.exception.CannotLeaveOwnerWithoutDelegationException;
+import com.neomango.team.exception.InvalidOwnerDelegationTargetException;
+import com.neomango.team.exception.NotTeamOwnerException;
+import com.neomango.team.exception.NotTeamMemberException;
+import com.neomango.team.exception.TeamOwnerInvariantViolationException;
+import com.neomango.team.repository.TeamApplicationRepository;
+import com.neomango.team.repository.TeamMemberRepository;
+import com.neomango.team.repository.TeamRepository;
+import com.neomango.team.repository.UserCategoryMembershipRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamMemberService {
+
+	private final TeamRepository teamRepository;
+	private final TeamApplicationRepository teamApplicationRepository;
+	private final TeamMemberRepository teamMemberRepository;
+	private final UserCategoryMembershipRepository userCategoryMembershipRepository;
+
+	public List<TeamMemberListResponse> getActiveTeamMembers(Long teamId) {
+		teamRepository.findByIdAndStatusNotAndDeletedAtIsNull(teamId, TeamStatus.DELETED)
+			.orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));
+
+		return teamMemberRepository.findActiveMembersByTeamId(teamId)
+			.stream()
+			.map(TeamMemberListResponse::from)
+			.toList();
+	}
+
+	@Transactional
+	public void leaveTeam(Long teamId, Long userId) {
+		Team team = teamRepository.findByIdAndStatusNotAndDeletedAtIsNull(teamId, TeamStatus.DELETED)
+			.orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));
+		TeamMember teamMember = teamMemberRepository.findActiveMemberByTeamIdAndUserId(teamId, userId)
+			.orElseThrow(NotTeamMemberException::new);
+
+		if (teamMember.isOwner()) {
+			leaveOwnerTeam(team, teamMember);
+			return;
+		}
+
+		deactivateMemberAndReleaseCategory(team, teamMember);
+	}
+
+	@Transactional
+	public void kickMember(Long teamId, Long targetTeamMemberId, Long requesterUserId) {
+		Team team = teamRepository.findByIdAndStatusNotAndDeletedAtIsNull(teamId, TeamStatus.DELETED)
+			.orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));
+		TeamMember requester = teamMemberRepository.findActiveMemberByTeamIdAndUserId(teamId, requesterUserId)
+			.orElseThrow(NotTeamOwnerException::new);
+
+		if (!requester.isOwner()) {
+			throw new NotTeamOwnerException();
+		}
+
+		TeamMember target = teamMemberRepository.findActiveMemberById(targetTeamMemberId)
+			.orElseThrow(NotTeamMemberException::new);
+		if (!target.getTeam().getId().equals(teamId)) {
+			throw new NotTeamMemberException();
+		}
+		if (requester.getId().equals(target.getId())) {
+			throw new CannotKickSelfException();
+		}
+		if (target.isOwner()) {
+			throw new CannotKickOwnerException();
+		}
+
+		target.deactivate();
+		userCategoryMembershipRepository.deleteByUserIdAndCategory(target.getUser().getId(), team.getCategory());
+	}
+
+	@Transactional
+	public void delegateOwner(Long teamId, Long requesterUserId, Long targetTeamMemberId) {
+		teamRepository.findByIdAndStatusNotAndDeletedAtIsNull(teamId, TeamStatus.DELETED)
+			.orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));
+		TeamMember requester = teamMemberRepository.findActiveMemberByTeamIdAndUserId(teamId, requesterUserId)
+			.orElseThrow(NotTeamOwnerException::new);
+
+		if (!requester.isOwner()) {
+			throw new NotTeamOwnerException();
+		}
+
+		TeamMember target = teamMemberRepository.findActiveMemberById(targetTeamMemberId)
+			.orElseThrow(NotTeamMemberException::new);
+		if (!target.getTeam().getId().equals(teamId)) {
+			throw new NotTeamMemberException();
+		}
+		if (requester.getId().equals(target.getId()) || target.isOwner()) {
+			throw new InvalidOwnerDelegationTargetException();
+		}
+
+		requester.changeRole(TeamMemberRole.MEMBER);
+		target.changeRole(TeamMemberRole.OWNER);
+		if (teamMemberRepository.countActiveOwnersByTeamId(teamId) != 1) {
+			throw new TeamOwnerInvariantViolationException();
+		}
+	}
+
+	private void leaveOwnerTeam(Team team, TeamMember ownerMember) {
+		long activeMemberCount = teamMemberRepository.countActiveMembersByTeamId(team.getId());
+		if (activeMemberCount > 1) {
+			throw new CannotLeaveOwnerWithoutDelegationException();
+		}
+
+		team.softDelete();
+		deactivateMemberAndReleaseCategory(team, ownerMember);
+		teamApplicationRepository.findByTeamIdAndStatusOrderByCreatedAtAsc(
+				team.getId(),
+				TeamApplicationStatus.PENDING
+			)
+			.forEach(TeamApplication::reject);
+	}
+
+	private void deactivateMemberAndReleaseCategory(Team team, TeamMember teamMember) {
+		teamMember.deactivate();
+		userCategoryMembershipRepository.deleteByUserIdAndCategory(
+			teamMember.getUser().getId(),
+			team.getCategory()
+		);
+	}
+}

--- a/src/main/java/com/neomango/team/service/TeamService.java
+++ b/src/main/java/com/neomango/team/service/TeamService.java
@@ -21,7 +21,6 @@ import com.neomango.team.dto.TeamSummaryResponse;
 import com.neomango.team.entity.Team;
 import com.neomango.team.entity.TeamMember;
 import com.neomango.team.entity.TeamMemberRole;
-import com.neomango.team.entity.TeamMemberStatus;
 import com.neomango.team.entity.TeamStatus;
 import com.neomango.team.repository.TeamMemberRepository;
 import com.neomango.team.repository.TeamRepository;
@@ -145,7 +144,7 @@ public class TeamService {
 	}
 
 	private void validateActiveOwner(TeamMember ownerMember, Long userId) {
-		if (!ownerMember.getUser().getId().equals(userId) || ownerMember.getStatus() != TeamMemberStatus.ACTIVE) {
+		if (!ownerMember.getUser().getId().equals(userId) || !ownerMember.isActive()) {
 			throw new BusinessException(ErrorCode.TEAM_OWNER_REQUIRED);
 		}
 	}

--- a/src/test/java/com/neomango/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/neomango/team/controller/TeamControllerTest.java
@@ -22,16 +22,20 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.neomango.auth.jwt.JwtTokenProvider;
+import com.neomango.team.dto.OwnerDelegationRequest;
 import com.neomango.team.dto.TeamApplicationCreateRequest;
 import com.neomango.team.dto.TeamCreateRequest;
 import com.neomango.team.entity.Team;
 import com.neomango.team.entity.TeamApplication;
 import com.neomango.team.entity.TeamMember;
 import com.neomango.team.entity.TeamApplicationStatus;
+import com.neomango.team.entity.TeamMemberStatus;
 import com.neomango.team.entity.TeamStatus;
+import com.neomango.team.entity.UserCategoryMembership;
 import com.neomango.team.repository.TeamApplicationRepository;
 import com.neomango.team.repository.TeamMemberRepository;
 import com.neomango.team.repository.TeamRepository;
+import com.neomango.team.repository.UserCategoryMembershipRepository;
 import com.neomango.user.entity.User;
 import com.neomango.user.entity.UserRole;
 import com.neomango.user.repository.UserRepository;
@@ -62,9 +66,13 @@ class TeamControllerTest {
 	@Autowired
 	private TeamApplicationRepository teamApplicationRepository;
 
+	@Autowired
+	private UserCategoryMembershipRepository userCategoryMembershipRepository;
+
 	@BeforeEach
 	void setUp() {
 		teamApplicationRepository.deleteAll();
+		userCategoryMembershipRepository.deleteAll();
 		teamMemberRepository.deleteAll();
 		teamRepository.deleteAll();
 		userRepository.deleteAll();
@@ -202,6 +210,707 @@ class TeamControllerTest {
 			.andExpect(jsonPath("$.data.members[0].nickname").value("owner"))
 			.andExpect(jsonPath("$.data.members[0].role").value("OWNER"))
 			.andExpect(jsonPath("$.data.members[0].status").value("ACTIVE"));
+	}
+
+	@Test
+	void getTeamMembersReturnsActiveMembersWhenAuthenticated() throws Exception {
+		User owner = userRepository.save(User.create("owner-members@test.com", "encoded-password", "owner"));
+		User member = userRepository.save(User.create("member-members@test.com", "encoded-password", "member"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, member));
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+		TeamMember ownerMember = savedTeam.getMembers().stream()
+			.filter(TeamMember::isOwner)
+			.findFirst()
+			.orElseThrow();
+		TeamMember normalMember = savedTeam.getMembers().stream()
+			.filter(teamMember -> !teamMember.isOwner())
+			.findFirst()
+			.orElseThrow();
+
+		mockMvc.perform(get("/api/teams/{teamId}/members", savedTeam.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.length()").value(2))
+			.andExpect(jsonPath("$.data[0].teamMemberId").value(ownerMember.getId()))
+			.andExpect(jsonPath("$.data[0].userId").value(owner.getId()))
+			.andExpect(jsonPath("$.data[0].nickname").value("owner"))
+			.andExpect(jsonPath("$.data[0].role").value("OWNER"))
+			.andExpect(jsonPath("$.data[0].status").value(TeamMemberStatus.ACTIVE.name()))
+			.andExpect(jsonPath("$.data[0].joinedAt").doesNotExist())
+			.andExpect(jsonPath("$.data[1].teamMemberId").value(normalMember.getId()))
+			.andExpect(jsonPath("$.data[1].userId").value(member.getId()))
+			.andExpect(jsonPath("$.data[1].nickname").value("member"))
+			.andExpect(jsonPath("$.data[1].role").value("MEMBER"))
+			.andExpect(jsonPath("$.data[1].status").value(TeamMemberStatus.ACTIVE.name()));
+	}
+
+	@Test
+	void getTeamMembersExcludesInactiveMembers() throws Exception {
+		User owner = userRepository.save(User.create("owner-active-members@test.com", "encoded-password", "owner"));
+		User activeUser = userRepository.save(User.create("active-member-list@test.com", "encoded-password", "activeMember"));
+		User inactiveUser = userRepository.save(User.create("inactive-member-list@test.com", "encoded-password", "inactiveMember"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, activeUser));
+		TeamMember inactiveMember = TeamMember.createMember(team, inactiveUser);
+		inactiveMember.deactivate();
+		team.addMember(inactiveMember);
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(get("/api/teams/{teamId}/members", savedTeam.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(2))
+			.andExpect(jsonPath("$.data[0].nickname").value("owner"))
+			.andExpect(jsonPath("$.data[1].nickname").value("activeMember"));
+	}
+
+	@Test
+	void getTeamMembersReturnsNotFoundWhenTeamIsDeleted() throws Exception {
+		User owner = userRepository.save(User.create("owner-deleted-members@test.com", "encoded-password", "owner"));
+		Team team = Team.create("Deleted Team", null, "GAME", owner);
+		team.softDelete();
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(get("/api/teams/{teamId}/members", savedTeam.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T001"));
+	}
+
+	@Test
+	void getTeamMembersReturnsNotFoundWhenTeamDoesNotExist() throws Exception {
+		User user = userRepository.save(User.create("member-not-found-team@test.com", "encoded-password", "member"));
+		String accessToken = jwtTokenProvider.createAccessToken(user.getId(), UserRole.USER);
+
+		mockMvc.perform(get("/api/teams/{teamId}/members", 999L)
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T001"));
+	}
+
+	@Test
+	void getTeamMembersRejectsRequestWithoutAuthentication() throws Exception {
+		User owner = userRepository.save(User.create("owner-members-auth@test.com", "encoded-password", "owner"));
+		Team team = teamRepository.save(Team.create("Game Team", null, "GAME", owner));
+
+		mockMvc.perform(get("/api/teams/{teamId}/members", team.getId()))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void leaveTeamSucceedsForNormalMember() throws Exception {
+		User owner = userRepository.save(User.create("owner-leave@test.com", "encoded-password", "owner"));
+		User member = userRepository.save(User.create("member-leave@test.com", "encoded-password", "member"));
+		User otherOwner = userRepository.save(User.create("other-owner-leave@test.com", "encoded-password", "otherOwner"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, member));
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		Team sportsTeam = teamRepository.saveAndFlush(Team.create("Sports Team", null, "SPORTS", otherOwner));
+		userCategoryMembershipRepository.saveAndFlush(UserCategoryMembership.create(member, "GAME", savedTeam));
+		userCategoryMembershipRepository.saveAndFlush(UserCategoryMembership.create(member, "SPORTS", sportsTeam));
+		TeamMember memberTeamMember = savedTeam.getMembers().stream()
+			.filter(teamMember -> teamMember.getUser().getId().equals(member.getId()))
+			.findFirst()
+			.orElseThrow();
+		String memberToken = jwtTokenProvider.createAccessToken(member.getId(), UserRole.USER);
+		String ownerToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/me/leave", savedTeam.getId())
+				.header("Authorization", "Bearer " + memberToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data").doesNotExist());
+
+		TeamMember leftMember = teamMemberRepository.findById(memberTeamMember.getId()).orElseThrow();
+		assertThat(leftMember.getStatus()).isEqualTo(TeamMemberStatus.INACTIVE);
+		assertThat(userCategoryMembershipRepository.existsByUserIdAndCategory(member.getId(), "GAME")).isFalse();
+		assertThat(userCategoryMembershipRepository.existsByUserIdAndCategory(member.getId(), "SPORTS")).isTrue();
+
+		mockMvc.perform(get("/api/teams/{teamId}/members", savedTeam.getId())
+				.header("Authorization", "Bearer " + ownerToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(1))
+			.andExpect(jsonPath("$.data[0].userId").value(owner.getId()));
+
+		userCategoryMembershipRepository.saveAndFlush(UserCategoryMembership.create(member, "GAME", savedTeam));
+		assertThat(userCategoryMembershipRepository.existsByUserIdAndCategory(member.getId(), "GAME")).isTrue();
+	}
+
+	@Test
+	void leaveTeamRejectsOwner() throws Exception {
+		User owner = userRepository.save(User.create("owner-leave-block@test.com", "encoded-password", "owner"));
+		User member = userRepository.save(User.create("member-leave-block@test.com", "encoded-password", "member"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, member));
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/me/leave", savedTeam.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value("T010"));
+
+		TeamMember ownerMember = savedTeam.getMembers().stream()
+			.filter(TeamMember::isOwner)
+			.findFirst()
+			.orElseThrow();
+		assertThat(teamMemberRepository.findById(ownerMember.getId()).orElseThrow().getStatus())
+			.isEqualTo(TeamMemberStatus.ACTIVE);
+	}
+
+	@Test
+	void leaveTeamDeletesTeamWhenOwnerIsOnlyActiveMember() throws Exception {
+		User owner = userRepository.save(User.create("owner-leave-solo@test.com", "encoded-password", "owner"));
+		User otherOwner = userRepository.save(User.create("other-owner-leave-solo@test.com", "encoded-password", "otherOwner"));
+		User applicant1 = userRepository.save(User.create("applicant1-leave-solo@test.com", "encoded-password", "applicant1"));
+		User applicant2 = userRepository.save(User.create("applicant2-leave-solo@test.com", "encoded-password", "applicant2"));
+		User applicant3 = userRepository.save(User.create("applicant3-leave-solo@test.com", "encoded-password", "applicant3"));
+		User applicant4 = userRepository.save(User.create("applicant4-leave-solo@test.com", "encoded-password", "applicant4"));
+		Team team = teamRepository.saveAndFlush(Team.create("Solo Owner Team", null, "GAME", owner));
+		Team sportsTeam = teamRepository.saveAndFlush(Team.create("Sports Team", null, "SPORTS", otherOwner));
+		userCategoryMembershipRepository.saveAndFlush(UserCategoryMembership.create(owner, "GAME", team));
+		userCategoryMembershipRepository.saveAndFlush(UserCategoryMembership.create(owner, "SPORTS", sportsTeam));
+		TeamApplication pendingApplication1 = saveApplication(
+			team,
+			applicant1,
+			"pending1",
+			LocalDateTime.of(2026, 5, 22, 10, 0),
+			TeamApplicationStatus.PENDING
+		);
+		TeamApplication pendingApplication2 = saveApplication(
+			team,
+			applicant2,
+			"pending2",
+			LocalDateTime.of(2026, 5, 22, 11, 0),
+			TeamApplicationStatus.PENDING
+		);
+		TeamApplication approvedApplication = saveApplication(
+			team,
+			applicant3,
+			"approved",
+			LocalDateTime.of(2026, 5, 22, 12, 0),
+			TeamApplicationStatus.APPROVED
+		);
+		TeamApplication canceledApplication = saveApplication(
+			team,
+			applicant4,
+			"canceled",
+			LocalDateTime.of(2026, 5, 22, 13, 0),
+			TeamApplicationStatus.CANCELED
+		);
+		TeamApplication rejectedApplication = saveApplication(
+			team,
+			applicant4,
+			"rejected",
+			LocalDateTime.of(2026, 5, 22, 14, 0),
+			TeamApplicationStatus.REJECTED
+		);
+		TeamMember ownerMember = team.getMembers().get(0);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/me/leave", team.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true));
+
+		Team deletedTeam = teamRepository.findById(team.getId()).orElseThrow();
+		assertThat(deletedTeam.getStatus()).isEqualTo(TeamStatus.DELETED);
+		assertThat(deletedTeam.getDeletedAt()).isNotNull();
+		assertThat(teamMemberRepository.findById(ownerMember.getId()).orElseThrow().getStatus())
+			.isEqualTo(TeamMemberStatus.INACTIVE);
+		assertThat(userCategoryMembershipRepository.existsByUserIdAndCategory(owner.getId(), "GAME")).isFalse();
+		assertThat(userCategoryMembershipRepository.existsByUserIdAndCategory(owner.getId(), "SPORTS")).isTrue();
+		assertThat(teamApplicationRepository.findById(pendingApplication1.getId()).orElseThrow().getStatus())
+			.isEqualTo(TeamApplicationStatus.REJECTED);
+		assertThat(teamApplicationRepository.findById(pendingApplication2.getId()).orElseThrow().getStatus())
+			.isEqualTo(TeamApplicationStatus.REJECTED);
+		assertThat(teamApplicationRepository.findById(approvedApplication.getId()).orElseThrow().getStatus())
+			.isEqualTo(TeamApplicationStatus.APPROVED);
+		assertThat(teamApplicationRepository.findById(canceledApplication.getId()).orElseThrow().getStatus())
+			.isEqualTo(TeamApplicationStatus.CANCELED);
+		assertThat(teamApplicationRepository.findById(rejectedApplication.getId()).orElseThrow().getStatus())
+			.isEqualTo(TeamApplicationStatus.REJECTED);
+
+		mockMvc.perform(get("/api/teams/{teamId}/members", team.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T001"));
+
+		Team newGameTeam = teamRepository.saveAndFlush(Team.create("New Game Team", null, "GAME", otherOwner));
+		userCategoryMembershipRepository.saveAndFlush(UserCategoryMembership.create(owner, "GAME", newGameTeam));
+		assertThat(userCategoryMembershipRepository.existsByUserIdAndCategory(owner.getId(), "GAME")).isTrue();
+	}
+
+	@Test
+	void leaveTeamRejectsUserWhoIsNotActiveTeamMember() throws Exception {
+		User owner = userRepository.save(User.create("owner-leave-non-member@test.com", "encoded-password", "owner"));
+		User outsider = userRepository.save(User.create("outsider-leave@test.com", "encoded-password", "outsider"));
+		Team team = teamRepository.saveAndFlush(Team.create("Game Team", null, "GAME", owner));
+		String accessToken = jwtTokenProvider.createAccessToken(outsider.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/me/leave", team.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T008"));
+	}
+
+	@Test
+	void leaveTeamRejectsDeletedTeam() throws Exception {
+		User owner = userRepository.save(User.create("owner-leave-deleted@test.com", "encoded-password", "owner"));
+		User member = userRepository.save(User.create("member-leave-deleted@test.com", "encoded-password", "member"));
+		Team team = Team.create("Deleted Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, member));
+		team.softDelete();
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		String accessToken = jwtTokenProvider.createAccessToken(member.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/me/leave", savedTeam.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T001"));
+	}
+
+	@Test
+	void leaveTeamRejectsMissingTeam() throws Exception {
+		User member = userRepository.save(User.create("member-leave-missing@test.com", "encoded-password", "member"));
+		String accessToken = jwtTokenProvider.createAccessToken(member.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/me/leave", 999L)
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T001"));
+	}
+
+	@Test
+	void leaveTeamRejectsRequestWithoutAuthentication() throws Exception {
+		User owner = userRepository.save(User.create("owner-leave-auth@test.com", "encoded-password", "owner"));
+		Team team = teamRepository.save(Team.create("Game Team", null, "GAME", owner));
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/me/leave", team.getId()))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void kickMemberSucceedsWhenRequesterIsOwner() throws Exception {
+		User owner = userRepository.save(User.create("owner-kick@test.com", "encoded-password", "owner"));
+		User target = userRepository.save(User.create("target-kick@test.com", "encoded-password", "target"));
+		User otherOwner = userRepository.save(User.create("other-owner-kick@test.com", "encoded-password", "otherOwner"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, target));
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		Team sportsTeam = teamRepository.saveAndFlush(Team.create("Sports Team", null, "SPORTS", otherOwner));
+		userCategoryMembershipRepository.saveAndFlush(UserCategoryMembership.create(target, "GAME", savedTeam));
+		userCategoryMembershipRepository.saveAndFlush(UserCategoryMembership.create(target, "SPORTS", sportsTeam));
+		TeamMember targetMember = savedTeam.getMembers().stream()
+			.filter(teamMember -> teamMember.getUser().getId().equals(target.getId()))
+			.findFirst()
+			.orElseThrow();
+		String ownerToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+		String targetToken = jwtTokenProvider.createAccessToken(target.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/{teamMemberId}/kick", savedTeam.getId(), targetMember.getId())
+				.header("Authorization", "Bearer " + ownerToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data").doesNotExist());
+
+		TeamMember kickedMember = teamMemberRepository.findById(targetMember.getId()).orElseThrow();
+		assertThat(kickedMember.getStatus()).isEqualTo(TeamMemberStatus.INACTIVE);
+		assertThat(userCategoryMembershipRepository.existsByUserIdAndCategory(target.getId(), "GAME")).isFalse();
+		assertThat(userCategoryMembershipRepository.existsByUserIdAndCategory(target.getId(), "SPORTS")).isTrue();
+
+		mockMvc.perform(get("/api/teams/{teamId}/members", savedTeam.getId())
+				.header("Authorization", "Bearer " + ownerToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(1))
+			.andExpect(jsonPath("$.data[0].userId").value(owner.getId()));
+
+		mockMvc.perform(post("/api/teams/{teamId}/applications", savedTeam.getId())
+				.header("Authorization", "Bearer " + targetToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new TeamApplicationCreateRequest("다시 가입하고 싶습니다."))))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.data.status").value(TeamApplicationStatus.PENDING.name()));
+	}
+
+	@Test
+	void kickMemberRejectsRequesterWhoIsNormalMember() throws Exception {
+		User owner = userRepository.save(User.create("owner-kick-member@test.com", "encoded-password", "owner"));
+		User requester = userRepository.save(User.create("requester-kick-member@test.com", "encoded-password", "requester"));
+		User target = userRepository.save(User.create("target-kick-member@test.com", "encoded-password", "target"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, requester));
+		team.addMember(TeamMember.createMember(team, target));
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		TeamMember targetMember = savedTeam.getMembers().stream()
+			.filter(teamMember -> teamMember.getUser().getId().equals(target.getId()))
+			.findFirst()
+			.orElseThrow();
+		String accessToken = jwtTokenProvider.createAccessToken(requester.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/{teamMemberId}/kick", savedTeam.getId(), targetMember.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("T002"));
+	}
+
+	@Test
+	void kickMemberRejectsSelfKick() throws Exception {
+		User owner = userRepository.save(User.create("owner-kick-self@test.com", "encoded-password", "owner"));
+		Team team = teamRepository.saveAndFlush(Team.create("Game Team", null, "GAME", owner));
+		TeamMember ownerMember = team.getMembers().get(0);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/{teamMemberId}/kick", team.getId(), ownerMember.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value("T009"));
+	}
+
+	@Test
+	void kickMemberRejectsOtherTeamMember() throws Exception {
+		User owner = userRepository.save(User.create("owner-kick-other-team@test.com", "encoded-password", "owner"));
+		User otherOwner = userRepository.save(User.create("other-owner-kick-other-team@test.com", "encoded-password", "otherOwner"));
+		User target = userRepository.save(User.create("target-kick-other-team@test.com", "encoded-password", "target"));
+		Team team = teamRepository.saveAndFlush(Team.create("Game Team", null, "GAME", owner));
+		Team otherTeam = Team.create("Other Team", null, "SPORTS", otherOwner);
+		otherTeam.addMember(TeamMember.createMember(otherTeam, target));
+		Team savedOtherTeam = teamRepository.saveAndFlush(otherTeam);
+		TeamMember otherTeamMember = savedOtherTeam.getMembers().stream()
+			.filter(teamMember -> teamMember.getUser().getId().equals(target.getId()))
+			.findFirst()
+			.orElseThrow();
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/{teamMemberId}/kick", team.getId(), otherTeamMember.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T008"));
+	}
+
+	@Test
+	void kickMemberRejectsMissingTeam() throws Exception {
+		User owner = userRepository.save(User.create("owner-kick-missing-team@test.com", "encoded-password", "owner"));
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/{teamMemberId}/kick", 999L, 1L)
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T001"));
+	}
+
+	@Test
+	void kickMemberRejectsMissingTeamMember() throws Exception {
+		User owner = userRepository.save(User.create("owner-kick-missing-member@test.com", "encoded-password", "owner"));
+		Team team = teamRepository.saveAndFlush(Team.create("Game Team", null, "GAME", owner));
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/{teamMemberId}/kick", team.getId(), 999L)
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T008"));
+	}
+
+	@Test
+	void kickMemberRejectsInactiveTeamMember() throws Exception {
+		User owner = userRepository.save(User.create("owner-kick-inactive@test.com", "encoded-password", "owner"));
+		User target = userRepository.save(User.create("target-kick-inactive@test.com", "encoded-password", "target"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		TeamMember inactiveMember = TeamMember.createMember(team, target);
+		inactiveMember.deactivate();
+		team.addMember(inactiveMember);
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/{teamMemberId}/kick", savedTeam.getId(), inactiveMember.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T008"));
+	}
+
+	@Test
+	void kickMemberRejectsDeletedTeam() throws Exception {
+		User owner = userRepository.save(User.create("owner-kick-deleted@test.com", "encoded-password", "owner"));
+		User target = userRepository.save(User.create("target-kick-deleted@test.com", "encoded-password", "target"));
+		Team team = Team.create("Deleted Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, target));
+		team.softDelete();
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		TeamMember targetMember = savedTeam.getMembers().stream()
+			.filter(teamMember -> teamMember.getUser().getId().equals(target.getId()))
+			.findFirst()
+			.orElseThrow();
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/{teamMemberId}/kick", savedTeam.getId(), targetMember.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T001"));
+	}
+
+	@Test
+	void kickMemberRejectsOwnerTarget() throws Exception {
+		User owner = userRepository.save(User.create("owner-kick-owner-target@test.com", "encoded-password", "owner"));
+		User targetOwner = userRepository.save(User.create("target-owner-kick@test.com", "encoded-password", "targetOwner"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		TeamMember targetOwnerMember = TeamMember.createOwner(team, targetOwner);
+		team.addMember(targetOwnerMember);
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/{teamMemberId}/kick", savedTeam.getId(), targetOwnerMember.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value("T012"));
+	}
+
+	@Test
+	void kickMemberRejectsRequestWithoutAuthentication() throws Exception {
+		User owner = userRepository.save(User.create("owner-kick-auth@test.com", "encoded-password", "owner"));
+		User target = userRepository.save(User.create("target-kick-auth@test.com", "encoded-password", "target"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, target));
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		TeamMember targetMember = savedTeam.getMembers().stream()
+			.filter(teamMember -> teamMember.getUser().getId().equals(target.getId()))
+			.findFirst()
+			.orElseThrow();
+
+		mockMvc.perform(post("/api/teams/{teamId}/members/{teamMemberId}/kick", savedTeam.getId(), targetMember.getId()))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void delegateOwnerSucceeds() throws Exception {
+		User owner = userRepository.save(User.create("owner-delegate@test.com", "encoded-password", "owner"));
+		User target = userRepository.save(User.create("target-delegate@test.com", "encoded-password", "target"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, target));
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		TeamMember ownerMember = savedTeam.getMembers().stream()
+			.filter(TeamMember::isOwner)
+			.findFirst()
+			.orElseThrow();
+		TeamMember targetMember = savedTeam.getMembers().stream()
+			.filter(teamMember -> teamMember.getUser().getId().equals(target.getId()))
+			.findFirst()
+			.orElseThrow();
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/owner/delegate", savedTeam.getId())
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new OwnerDelegationRequest(targetMember.getId()))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data").doesNotExist());
+
+		assertThat(teamMemberRepository.findById(ownerMember.getId()).orElseThrow().getRole())
+			.isEqualTo(com.neomango.team.entity.TeamMemberRole.MEMBER);
+		assertThat(teamMemberRepository.findById(targetMember.getId()).orElseThrow().getRole())
+			.isEqualTo(com.neomango.team.entity.TeamMemberRole.OWNER);
+		assertThat(teamMemberRepository.countActiveOwnersByTeamId(savedTeam.getId())).isEqualTo(1);
+
+		String targetToken = jwtTokenProvider.createAccessToken(target.getId(), UserRole.USER);
+		mockMvc.perform(get("/api/teams/{teamId}/members", savedTeam.getId())
+				.header("Authorization", "Bearer " + targetToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data[0].userId").value(owner.getId()))
+			.andExpect(jsonPath("$.data[0].role").value("MEMBER"))
+			.andExpect(jsonPath("$.data[1].userId").value(target.getId()))
+			.andExpect(jsonPath("$.data[1].role").value("OWNER"));
+	}
+
+	@Test
+	void delegateOwnerRejectsRequesterWhoIsNormalMember() throws Exception {
+		User owner = userRepository.save(User.create("owner-delegate-member@test.com", "encoded-password", "owner"));
+		User requester = userRepository.save(User.create("requester-delegate-member@test.com", "encoded-password", "requester"));
+		User target = userRepository.save(User.create("target-delegate-member@test.com", "encoded-password", "target"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, requester));
+		team.addMember(TeamMember.createMember(team, target));
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		TeamMember targetMember = savedTeam.getMembers().stream()
+			.filter(teamMember -> teamMember.getUser().getId().equals(target.getId()))
+			.findFirst()
+			.orElseThrow();
+		String accessToken = jwtTokenProvider.createAccessToken(requester.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/owner/delegate", savedTeam.getId())
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new OwnerDelegationRequest(targetMember.getId()))))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("T002"));
+	}
+
+	@Test
+	void delegateOwnerRejectsSelfDelegation() throws Exception {
+		User owner = userRepository.save(User.create("owner-delegate-self@test.com", "encoded-password", "owner"));
+		Team team = teamRepository.saveAndFlush(Team.create("Game Team", null, "GAME", owner));
+		TeamMember ownerMember = team.getMembers().get(0);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/owner/delegate", team.getId())
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new OwnerDelegationRequest(ownerMember.getId()))))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value("T011"));
+	}
+
+	@Test
+	void delegateOwnerRejectsOtherTeamMember() throws Exception {
+		User owner = userRepository.save(User.create("owner-delegate-other-team@test.com", "encoded-password", "owner"));
+		User otherOwner = userRepository.save(User.create("other-owner-delegate@test.com", "encoded-password", "otherOwner"));
+		User target = userRepository.save(User.create("target-delegate-other-team@test.com", "encoded-password", "target"));
+		Team team = teamRepository.saveAndFlush(Team.create("Game Team", null, "GAME", owner));
+		Team otherTeam = Team.create("Other Team", null, "SPORTS", otherOwner);
+		otherTeam.addMember(TeamMember.createMember(otherTeam, target));
+		Team savedOtherTeam = teamRepository.saveAndFlush(otherTeam);
+		TeamMember otherTeamMember = savedOtherTeam.getMembers().stream()
+			.filter(teamMember -> teamMember.getUser().getId().equals(target.getId()))
+			.findFirst()
+			.orElseThrow();
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/owner/delegate", team.getId())
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new OwnerDelegationRequest(otherTeamMember.getId()))))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T008"));
+	}
+
+	@Test
+	void delegateOwnerRejectsMissingTeam() throws Exception {
+		User owner = userRepository.save(User.create("owner-delegate-missing-team@test.com", "encoded-password", "owner"));
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/owner/delegate", 999L)
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new OwnerDelegationRequest(1L))))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T001"));
+	}
+
+	@Test
+	void delegateOwnerRejectsMissingTeamMember() throws Exception {
+		User owner = userRepository.save(User.create("owner-delegate-missing-member@test.com", "encoded-password", "owner"));
+		Team team = teamRepository.saveAndFlush(Team.create("Game Team", null, "GAME", owner));
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/owner/delegate", team.getId())
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new OwnerDelegationRequest(999L))))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T008"));
+	}
+
+	@Test
+	void delegateOwnerRejectsInactiveTeamMember() throws Exception {
+		User owner = userRepository.save(User.create("owner-delegate-inactive@test.com", "encoded-password", "owner"));
+		User target = userRepository.save(User.create("target-delegate-inactive@test.com", "encoded-password", "target"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		TeamMember inactiveMember = TeamMember.createMember(team, target);
+		inactiveMember.deactivate();
+		team.addMember(inactiveMember);
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/owner/delegate", savedTeam.getId())
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new OwnerDelegationRequest(inactiveMember.getId()))))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T008"));
+	}
+
+	@Test
+	void delegateOwnerRejectsOwnerTarget() throws Exception {
+		User owner = userRepository.save(User.create("owner-delegate-owner-target@test.com", "encoded-password", "owner"));
+		User targetOwner = userRepository.save(User.create("target-owner-delegate@test.com", "encoded-password", "targetOwner"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		TeamMember targetOwnerMember = TeamMember.createOwner(team, targetOwner);
+		team.addMember(targetOwnerMember);
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/owner/delegate", savedTeam.getId())
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new OwnerDelegationRequest(targetOwnerMember.getId()))))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value("T011"));
+	}
+
+	@Test
+	void delegateOwnerRejectsDeletedTeam() throws Exception {
+		User owner = userRepository.save(User.create("owner-delegate-deleted@test.com", "encoded-password", "owner"));
+		User target = userRepository.save(User.create("target-delegate-deleted@test.com", "encoded-password", "target"));
+		Team team = Team.create("Deleted Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, target));
+		team.softDelete();
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		TeamMember targetMember = savedTeam.getMembers().stream()
+			.filter(teamMember -> teamMember.getUser().getId().equals(target.getId()))
+			.findFirst()
+			.orElseThrow();
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/owner/delegate", savedTeam.getId())
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new OwnerDelegationRequest(targetMember.getId()))))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("T001"));
+	}
+
+	@Test
+	void delegateOwnerRejectsWhenActiveOwnerCountIsNotOneAfterDelegation() throws Exception {
+		User owner = userRepository.save(User.create("owner-delegate-count@test.com", "encoded-password", "owner"));
+		User anotherOwner = userRepository.save(User.create("another-owner-delegate-count@test.com", "encoded-password", "anotherOwner"));
+		User target = userRepository.save(User.create("target-delegate-count@test.com", "encoded-password", "target"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		TeamMember anotherOwnerMember = TeamMember.createOwner(team, anotherOwner);
+		TeamMember targetMember = TeamMember.createMember(team, target);
+		team.addMember(anotherOwnerMember);
+		team.addMember(targetMember);
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		String accessToken = jwtTokenProvider.createAccessToken(owner.getId(), UserRole.USER);
+
+		mockMvc.perform(post("/api/teams/{teamId}/owner/delegate", savedTeam.getId())
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new OwnerDelegationRequest(targetMember.getId()))))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value("T013"));
+		assertThat(teamMemberRepository.countActiveOwnersByTeamId(savedTeam.getId())).isEqualTo(2);
+	}
+
+	@Test
+	void delegateOwnerRejectsRequestWithoutAuthentication() throws Exception {
+		User owner = userRepository.save(User.create("owner-delegate-auth@test.com", "encoded-password", "owner"));
+		User target = userRepository.save(User.create("target-delegate-auth@test.com", "encoded-password", "target"));
+		Team team = Team.create("Game Team", null, "GAME", owner);
+		team.addMember(TeamMember.createMember(team, target));
+		Team savedTeam = teamRepository.saveAndFlush(team);
+		TeamMember targetMember = savedTeam.getMembers().stream()
+			.filter(teamMember -> teamMember.getUser().getId().equals(target.getId()))
+			.findFirst()
+			.orElseThrow();
+
+		mockMvc.perform(post("/api/teams/{teamId}/owner/delegate", savedTeam.getId())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new OwnerDelegationRequest(targetMember.getId()))))
+			.andExpect(status().isUnauthorized());
 	}
 
 	@Test

--- a/src/test/java/com/neomango/team/entity/TeamMemberTest.java
+++ b/src/test/java/com/neomango/team/entity/TeamMemberTest.java
@@ -1,0 +1,63 @@
+package com.neomango.team.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.neomango.team.exception.NotTeamMemberException;
+import com.neomango.team.exception.NotTeamOwnerException;
+import com.neomango.user.entity.User;
+
+class TeamMemberTest {
+
+	@Test
+	void deactivateChangesStatusToInactive() {
+		TeamMember teamMember = TeamMember.createMember(team(), user());
+
+		teamMember.deactivate();
+
+		assertThat(teamMember.getStatus()).isEqualTo(TeamMemberStatus.INACTIVE);
+		assertThat(teamMember.isActive()).isFalse();
+	}
+
+	@Test
+	void changeRoleChangesMemberRole() {
+		TeamMember teamMember = TeamMember.createMember(team(), user());
+
+		teamMember.changeRole(TeamMemberRole.OWNER);
+
+		assertThat(teamMember.getRole()).isEqualTo(TeamMemberRole.OWNER);
+		assertThat(teamMember.isOwner()).isTrue();
+	}
+
+	@Test
+	void validateActiveThrowsExceptionWhenInactive() {
+		TeamMember teamMember = TeamMember.createMember(team(), user());
+		teamMember.deactivate();
+
+		assertThatThrownBy(teamMember::validateActive)
+			.isInstanceOf(NotTeamMemberException.class);
+	}
+
+	@Test
+	void validateOwnerThrowsExceptionWhenMember() {
+		TeamMember teamMember = TeamMember.createMember(team(), user());
+
+		assertThatThrownBy(teamMember::validateOwner)
+			.isInstanceOf(NotTeamOwnerException.class);
+	}
+
+	private Team team() {
+		Team team = Team.create("Team", null, "GAME", user());
+		ReflectionTestUtils.setField(team, "id", 1L);
+		return team;
+	}
+
+	private User user() {
+		User user = User.create("user@test.com", "encoded-password", "user");
+		ReflectionTestUtils.setField(user, "id", 1L);
+		return user;
+	}
+}

--- a/src/test/java/com/neomango/team/repository/TeamRepositoryTest.java
+++ b/src/test/java/com/neomango/team/repository/TeamRepositoryTest.java
@@ -225,6 +225,85 @@ class TeamRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("active TeamMember queries exclude inactive members")
+	void activeTeamMemberQueriesExcludeInactiveMembers() {
+		User owner = saveUser("owner-active-query@test.com", "ownerActiveQuery");
+		User activeUser = saveUser("active-member@test.com", "activeMember");
+		User inactiveUser = saveUser("inactive-member@test.com", "inactiveMember");
+		Team team = teamRepository.saveAndFlush(Team.create("Active Query Team", null, "GAME", owner));
+		TeamMember activeMember = teamMemberRepository.saveAndFlush(TeamMember.createMember(team, activeUser));
+		TeamMember inactiveMember = TeamMember.createMember(team, inactiveUser);
+		inactiveMember.deactivate();
+		teamMemberRepository.saveAndFlush(inactiveMember);
+		entityManager.clear();
+
+		assertThat(teamMemberRepository.findActiveMembersByTeamId(team.getId()))
+			.extracting(teamMember -> teamMember.getUser().getId())
+			.contains(activeUser.getId())
+			.doesNotContain(inactiveUser.getId());
+		assertThat(teamMemberRepository.findActiveMemberByTeamIdAndUserId(team.getId(), activeUser.getId()))
+			.isPresent();
+		assertThat(teamMemberRepository.findActiveMemberByTeamIdAndUserId(team.getId(), inactiveUser.getId()))
+			.isEmpty();
+		assertThat(teamMemberRepository.findActiveMemberById(activeMember.getId())).isPresent();
+		assertThat(teamMemberRepository.findActiveMemberById(inactiveMember.getId())).isEmpty();
+		assertThat(teamMemberRepository.existsActiveMemberByTeamIdAndUserId(team.getId(), activeUser.getId())).isTrue();
+		assertThat(teamMemberRepository.existsActiveMemberByTeamIdAndUserId(team.getId(), inactiveUser.getId())).isFalse();
+	}
+
+	@Test
+	@DisplayName("find active owner by team id returns active owner only")
+	void findActiveOwnerByTeamIdReturnsActiveOwnerOnly() {
+		User owner = saveUser("owner-active-owner@test.com", "ownerActiveOwner");
+		User nextOwner = saveUser("next-owner@test.com", "nextOwner");
+		Team team = teamRepository.saveAndFlush(Team.create("Owner Query Team", null, "GAME", owner));
+		TeamMember originalOwner = team.getMembers().get(0);
+		originalOwner.deactivate();
+		teamMemberRepository.saveAndFlush(TeamMember.createOwner(team, nextOwner));
+		entityManager.flush();
+		entityManager.clear();
+
+		TeamMember activeOwner = teamMemberRepository.findActiveOwnerByTeamId(team.getId()).orElseThrow();
+
+		assertThat(activeOwner.getUser().getId()).isEqualTo(nextOwner.getId());
+		assertThat(activeOwner.getStatus()).isEqualTo(TeamMemberStatus.ACTIVE);
+	}
+
+	@Test
+	@DisplayName("count active members by team id counts active members only")
+	void countActiveMembersByTeamIdCountsActiveMembersOnly() {
+		User owner = saveUser("owner-count-active@test.com", "ownerCountActive");
+		User activeUser = saveUser("count-active@test.com", "countActive");
+		User inactiveUser = saveUser("count-inactive@test.com", "countInactive");
+		Team team = teamRepository.saveAndFlush(Team.create("Count Active Team", null, "GAME", owner));
+		teamMemberRepository.saveAndFlush(TeamMember.createMember(team, activeUser));
+		TeamMember inactiveMember = TeamMember.createMember(team, inactiveUser);
+		inactiveMember.deactivate();
+		teamMemberRepository.saveAndFlush(inactiveMember);
+
+		assertThat(teamMemberRepository.countActiveMembersByTeamId(team.getId())).isEqualTo(2);
+		assertThat(teamMemberRepository.countActiveOwnersByTeamId(team.getId())).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("delete UserCategoryMembership by user id and category deletes matching category only")
+	void deleteByUserIdAndCategoryDeletesMatchingCategoryOnly() {
+		User owner = saveUser("owner-delete-category@test.com", "ownerDeleteCategory");
+		User member = saveUser("member-delete-category@test.com", "memberDeleteCategory");
+		Team gameTeam = teamRepository.saveAndFlush(Team.create("Game Delete Category Team", null, "GAME", owner));
+		Team sportsTeam = teamRepository.saveAndFlush(Team.create("Sports Delete Category Team", null, "SPORTS", owner));
+		userCategoryMembershipRepository.saveAndFlush(UserCategoryMembership.create(member, "GAME", gameTeam));
+		userCategoryMembershipRepository.saveAndFlush(UserCategoryMembership.create(member, "SPORTS", sportsTeam));
+
+		long deletedCount = userCategoryMembershipRepository.deleteByUserIdAndCategory(member.getId(), "GAME");
+		entityManager.flush();
+
+		assertThat(deletedCount).isEqualTo(1);
+		assertThat(userCategoryMembershipRepository.existsByUserIdAndCategory(member.getId(), "GAME")).isFalse();
+		assertThat(userCategoryMembershipRepository.existsByUserIdAndCategory(member.getId(), "SPORTS")).isTrue();
+	}
+
+	@Test
 	@DisplayName("team application fetch join methods initialize required association")
 	void teamApplicationFetchJoinMethodsInitializeRequiredAssociation() {
 		User owner = saveUser("owner10@test.com", "owner10");

--- a/src/test/java/com/neomango/team/service/TeamServiceTest.java
+++ b/src/test/java/com/neomango/team/service/TeamServiceTest.java
@@ -296,7 +296,7 @@ class TeamServiceTest {
 		User owner = activeUser();
 		Team team = savedTeam(20L, owner, "GAME");
 		TeamMember ownerMember = team.getMembers().get(0);
-		ReflectionTestUtils.setField(ownerMember, "status", TeamMemberStatus.LEFT);
+		ReflectionTestUtils.setField(ownerMember, "status", TeamMemberStatus.INACTIVE);
 		when(teamRepository.findByIdAndStatusNotAndDeletedAtIsNull(20L, TeamStatus.DELETED))
 			.thenReturn(Optional.of(team));
 		when(teamMemberRepository.findByTeamIdAndRole(20L, TeamMemberRole.OWNER)).thenReturn(Optional.of(ownerMember));
@@ -364,7 +364,7 @@ class TeamServiceTest {
 		User owner = activeUser();
 		Team team = savedTeam(24L, owner, "GAME");
 		TeamMember ownerMember = team.getMembers().get(0);
-		ReflectionTestUtils.setField(ownerMember, "status", TeamMemberStatus.KICKED);
+		ReflectionTestUtils.setField(ownerMember, "status", TeamMemberStatus.INACTIVE);
 		when(teamRepository.findByIdAndStatusNotAndDeletedAtIsNull(24L, TeamStatus.DELETED))
 			.thenReturn(Optional.of(team));
 		when(teamMemberRepository.findByTeamIdAndRole(24L, TeamMemberRole.OWNER)).thenReturn(Optional.of(ownerMember));


### PR DESCRIPTION
## 📝 개요
Phase 4 팀원 관리 기능을 구현했음.
TeamMember를 ACTIVE/INACTIVE 기반으로 정리하고, 팀원 목록 조회, 일반 탈퇴, 강퇴, OWNER 위임, OWNER 단독 탈퇴 시 팀 삭제 정책을 반영했음.

## 🚀 주요 변경 사항
도메인 변경:
- TeamMemberStatus를 ACTIVE / INACTIVE로 정리했음.
- TeamMember에 상태/역할 변경 도메인 메서드를 추가했음.
- 팀원 관리 전용 예외와 ErrorCode를 추가했음.

핵심 로직:
- ACTIVE 팀원 목록 조회 API를 추가했음.
- 일반 MEMBER 탈퇴 시 TeamMember를 INACTIVE 처리하고 해당 category membership을 삭제했음.
- OWNER 강퇴 기능을 추가하고 자기 자신/다른 팀/INACTIVE/OWNER 대상 강퇴를 차단했음.
- OWNER 위임 기능을 추가하고 위임 후 ACTIVE OWNER count를 검증했음.
- OWNER 단독 탈퇴 시 Team DELETED, OWNER TeamMember INACTIVE, UserCategoryMembership 삭제, PENDING 신청 REJECTED 처리를 하나의 트랜잭션에서 수행했음.

인프라:
- Security/JWT/Auth 설정은 변경하지 않았음.
- Querydsl, 알림, 감사 로그, 이력 테이블은 추가하지 않았음.

## 🔍 리뷰 포인트 (Trade-off)
- OWNER 단일성은 이번 단계에서 DB partial unique constraint 없이 트랜잭션 내 role 변경과 active owner count 검증으로 우선 보장했음.
- UserCategoryMembership은 팀원 목록 조회에 사용하지 않고, 사용자-카테고리 점유 해제 용도로만 사용했음.
- 탈퇴/강퇴 이력과 시각은 정책에 따라 저장하지 않았음.

## 📸 테스트 결과
- ./gradlew.bat test 성공했음.
- 팀원 목록, 탈퇴, 강퇴, OWNER 위임, OWNER 단독 탈퇴 및 기존 TeamApplication 승인/거절 회귀 테스트를 포함했음.