### PR TITLE
fix: alllow rejoin approval inactive member

### DIFF
--- a/src/main/java/com/neomango/team/entity/TeamMember.java
+++ b/src/main/java/com/neomango/team/entity/TeamMember.java
@@ -2,6 +2,7 @@ package com.neomango.team.entity;
 
 import java.time.LocalDateTime;
 
+import com.neomango.team.exception.DuplicateTeamMemberException;
 import com.neomango.team.exception.NotTeamMemberException;
 import com.neomango.team.exception.NotTeamOwnerException;
 import com.neomango.user.entity.User;
@@ -80,6 +81,16 @@ public class TeamMember {
 
 	public void deactivate() {
 		this.status = TeamMemberStatus.INACTIVE;
+	}
+
+	public void rejoinAsMember() {
+		if (isActive()) {
+			throw new DuplicateTeamMemberException();
+		}
+
+		this.role = TeamMemberRole.MEMBER;
+		this.status = TeamMemberStatus.ACTIVE;
+		this.joinedAt = LocalDateTime.now();
 	}
 
 	public void changeRole(TeamMemberRole role) {

--- a/src/main/java/com/neomango/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/neomango/team/repository/TeamMemberRepository.java
@@ -71,6 +71,8 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
 	Optional<TeamMember> findByTeamIdAndRole(Long teamId, TeamMemberRole role);
 
+	Optional<TeamMember> findByTeamIdAndUserId(Long teamId, Long userId);
+
 	@Query("""
 		select teamMember
 		from TeamMember teamMember

--- a/src/main/java/com/neomango/team/service/TeamApplicationService.java
+++ b/src/main/java/com/neomango/team/service/TeamApplicationService.java
@@ -20,7 +20,6 @@ import com.neomango.team.entity.TeamMemberRole;
 import com.neomango.team.entity.TeamMemberStatus;
 import com.neomango.team.entity.TeamStatus;
 import com.neomango.team.entity.UserCategoryMembership;
-import com.neomango.team.exception.DuplicateTeamMemberException;
 import com.neomango.team.exception.NotTeamOwnerException;
 import com.neomango.team.repository.TeamApplicationRepository;
 import com.neomango.team.repository.TeamMemberRepository;
@@ -94,14 +93,10 @@ public class TeamApplicationService {
 		Team team = application.getTeam();
 		User applicant = application.getApplicant();
 		validateApplicationProcessOwner(team, loginUserId);
-		validateNoDuplicateTeamMember(team, applicant);
 		validateApplicantIsNotTeamMember(team, applicant);
 		validateApplicantIsNotSameCategoryMember(team, applicant);
 		createUserCategoryMembership(applicant, team);
-
-		TeamMember teamMember = TeamMember.createMember(team, applicant);
-		team.addMember(teamMember);
-		teamMemberRepository.save(teamMember);
+		activateOrCreateTeamMember(team, applicant);
 
 		application.approve();
 		cancelOtherPendingApplicationsInSameCategory(application);
@@ -213,10 +208,16 @@ public class TeamApplicationService {
 		}
 	}
 
-	private void validateNoDuplicateTeamMember(Team team, User applicant) {
-		if (teamMemberRepository.existsByTeamIdAndUserId(team.getId(), applicant.getId())) {
-			throw new DuplicateTeamMemberException();
-		}
+	private void activateOrCreateTeamMember(Team team, User applicant) {
+		teamMemberRepository.findByTeamIdAndUserId(team.getId(), applicant.getId())
+			.ifPresentOrElse(
+				TeamMember::rejoinAsMember,
+				() -> {
+					TeamMember teamMember = TeamMember.createMember(team, applicant);
+					team.addMember(teamMember);
+					teamMemberRepository.save(teamMember);
+				}
+			);
 	}
 
 	private void cancelOtherPendingApplicationsInSameCategory(TeamApplication approvedApplication) {

--- a/src/test/java/com/neomango/team/controller/TeamApplicationControllerTest.java
+++ b/src/test/java/com/neomango/team/controller/TeamApplicationControllerTest.java
@@ -234,7 +234,7 @@ class TeamApplicationControllerTest {
 	}
 
 	@Test
-	void approveApplication_failsWhenDuplicateTeamMemberExists() throws Exception {
+	void approveApplication_failsWhenApplicantIsActiveTeamMember() throws Exception {
 		User owner = userRepository.save(User.create("owner@test.com", "encoded-password", "owner"));
 		User applicant = userRepository.save(User.create("applicant@test.com", "encoded-password", "applicant"));
 		Team team = teamRepository.save(Team.create("Futsal Team", null, "FUTSAL", owner));
@@ -247,7 +247,7 @@ class TeamApplicationControllerTest {
 		mockMvc.perform(post("/api/team-applications/{applicationId}/approve", application.getId())
 				.header("Authorization", "Bearer " + accessToken))
 			.andExpect(status().isConflict())
-			.andExpect(jsonPath("$.code").value("T004"));
+			.andExpect(jsonPath("$.code").value("T003"));
 	}
 
 	@Test

--- a/src/test/java/com/neomango/team/service/TeamApplicationReapplyIntegrationTest.java
+++ b/src/test/java/com/neomango/team/service/TeamApplicationReapplyIntegrationTest.java
@@ -1,0 +1,228 @@
+package com.neomango.team.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+import com.neomango.team.dto.TeamApplicationCreateRequest;
+import com.neomango.team.dto.TeamApplicationResponse;
+import com.neomango.team.dto.TeamMemberListResponse;
+import com.neomango.team.entity.Team;
+import com.neomango.team.entity.TeamApplication;
+import com.neomango.team.entity.TeamApplicationStatus;
+import com.neomango.team.entity.TeamMember;
+import com.neomango.team.entity.TeamMemberRole;
+import com.neomango.team.entity.TeamMemberStatus;
+import com.neomango.team.repository.TeamApplicationRepository;
+import com.neomango.team.repository.TeamMemberRepository;
+import com.neomango.team.repository.TeamRepository;
+import com.neomango.team.repository.UserCategoryMembershipRepository;
+import com.neomango.user.entity.User;
+import com.neomango.user.repository.UserRepository;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class TeamApplicationReapplyIntegrationTest {
+
+	private static final String CATEGORY = "LEAGUE_OF_LEGENDS";
+
+	@Autowired
+	private TeamApplicationService teamApplicationService;
+
+	@Autowired
+	private TeamMemberService teamMemberService;
+
+	@Autowired
+	private TeamApplicationRepository teamApplicationRepository;
+
+	@Autowired
+	private TeamMemberRepository teamMemberRepository;
+
+	@Autowired
+	private UserCategoryMembershipRepository userCategoryMembershipRepository;
+
+	@Autowired
+	private TeamRepository teamRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@BeforeEach
+	void setUp() {
+		cleanUp();
+	}
+
+	@AfterEach
+	void tearDown() {
+		cleanUp();
+	}
+
+	private void cleanUp() {
+		teamApplicationRepository.deleteAll();
+		userCategoryMembershipRepository.deleteAll();
+		teamMemberRepository.deleteAll();
+		teamRepository.deleteAll();
+		userRepository.deleteAll();
+	}
+
+	@Test
+	void leftMemberCanReapplyAndBeApprovedWithoutDuplicateTeamMemberRow() {
+		ReapplyFixture fixture = createLeftOwnerFixture();
+
+		TeamApplicationResponse reapplyResponse = teamApplicationService.createApplication(
+			fixture.team().getId(),
+			fixture.tester1().getId(),
+			request("rejoin")
+		);
+
+		TeamApplicationResponse approvedResponse = teamApplicationService.approveApplication(
+			reapplyResponse.applicationId(),
+			fixture.tester2().getId()
+		);
+
+		TeamMember rejoinedMember = teamMemberRepository
+			.findByTeamIdAndUserId(fixture.team().getId(), fixture.tester1().getId())
+			.orElseThrow();
+		TeamApplication approvedApplication = teamApplicationRepository
+			.findById(reapplyResponse.applicationId())
+			.orElseThrow();
+
+		assertThat(approvedResponse.status()).isEqualTo(TeamApplicationStatus.APPROVED);
+		assertThat(approvedApplication.getStatus()).isEqualTo(TeamApplicationStatus.APPROVED);
+		assertThat(rejoinedMember.getStatus()).isEqualTo(TeamMemberStatus.ACTIVE);
+		assertThat(rejoinedMember.getRole()).isEqualTo(TeamMemberRole.MEMBER);
+		assertThat(teamMemberRepository.countByTeamIdAndUserId(fixture.team().getId(), fixture.tester1().getId()))
+			.isEqualTo(1);
+		assertThat(teamMemberService.getActiveTeamMembers(fixture.team().getId()))
+			.extracting(TeamMemberListResponse::userId)
+			.contains(fixture.tester1().getId());
+	}
+
+	@Test
+	void activeMemberCannotBeApprovedAgainAndDuplicateTeamMemberRowIsNotCreated() {
+		User owner = userRepository.save(User.create("owner-active@test.com", "encoded-password", "owner"));
+		User activeMember = userRepository.save(User.create("member-active@test.com", "encoded-password", "member"));
+		Team team = teamRepository.save(Team.create("t1", null, CATEGORY, owner));
+		TeamMember member = TeamMember.createMember(team, activeMember);
+		team.addMember(member);
+		teamMemberRepository.save(member);
+		TeamApplication application = teamApplicationRepository.save(
+			TeamApplication.create(team, activeMember, "duplicate")
+		);
+
+		assertThatThrownBy(() -> teamApplicationService.approveApplication(application.getId(), owner.getId()))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.ALREADY_TEAM_MEMBER);
+		assertThat(teamMemberRepository.countByTeamIdAndUserId(team.getId(), activeMember.getId())).isEqualTo(1);
+	}
+
+	@Test
+	void approvingReapplyReactivatesExistingInactiveTeamMemberRow() {
+		ReapplyFixture fixture = createLeftOwnerFixture();
+		TeamMember inactiveMember = teamMemberRepository
+			.findByTeamIdAndUserId(fixture.team().getId(), fixture.tester1().getId())
+			.orElseThrow();
+		Long inactiveMemberId = inactiveMember.getId();
+		TeamApplicationResponse reapplyResponse = teamApplicationService.createApplication(
+			fixture.team().getId(),
+			fixture.tester1().getId(),
+			request("rejoin")
+		);
+
+		teamApplicationService.approveApplication(reapplyResponse.applicationId(), fixture.tester2().getId());
+
+		TeamMember reactivatedMember = teamMemberRepository
+			.findByTeamIdAndUserId(fixture.team().getId(), fixture.tester1().getId())
+			.orElseThrow();
+		assertThat(reactivatedMember.getId()).isEqualTo(inactiveMemberId);
+		assertThat(reactivatedMember.getStatus()).isEqualTo(TeamMemberStatus.ACTIVE);
+		assertThat(teamMemberRepository.countByTeamIdAndUserId(fixture.team().getId(), fixture.tester1().getId()))
+			.isEqualTo(1);
+	}
+
+	@Test
+	void leftMemberCanCreateReapplyButCannotCreateDuplicatePendingApplication() {
+		ReapplyFixture fixture = createLeftOwnerFixture();
+
+		TeamApplicationResponse response = teamApplicationService.createApplication(
+			fixture.team().getId(),
+			fixture.tester1().getId(),
+			request("rejoin")
+		);
+
+		assertThat(response.status()).isEqualTo(TeamApplicationStatus.PENDING);
+		assertThatThrownBy(() -> teamApplicationService.createApplication(
+			fixture.team().getId(),
+			fixture.tester1().getId(),
+			request("duplicate")
+		))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.DUPLICATE_PENDING_TEAM_APPLICATION);
+	}
+
+	@Test
+	void rejectingLeftMemberReapplyKeepsTeamMemberInactive() {
+		ReapplyFixture fixture = createLeftOwnerFixture();
+		TeamApplicationResponse reapplyResponse = teamApplicationService.createApplication(
+			fixture.team().getId(),
+			fixture.tester1().getId(),
+			request("rejoin")
+		);
+
+		TeamApplicationResponse rejectedResponse = teamApplicationService.rejectApplication(
+			reapplyResponse.applicationId(),
+			fixture.tester2().getId()
+		);
+
+		TeamApplication rejectedApplication = teamApplicationRepository
+			.findById(reapplyResponse.applicationId())
+			.orElseThrow();
+		TeamMember leftMember = teamMemberRepository
+			.findByTeamIdAndUserId(fixture.team().getId(), fixture.tester1().getId())
+			.orElseThrow();
+
+		assertThat(rejectedResponse.status()).isEqualTo(TeamApplicationStatus.REJECTED);
+		assertThat(rejectedApplication.getStatus()).isEqualTo(TeamApplicationStatus.REJECTED);
+		assertThat(leftMember.getStatus()).isEqualTo(TeamMemberStatus.INACTIVE);
+		assertThat(teamMemberRepository.countByTeamIdAndUserId(fixture.team().getId(), fixture.tester1().getId()))
+			.isEqualTo(1);
+	}
+
+	private ReapplyFixture createLeftOwnerFixture() {
+		User tester1 = userRepository.save(User.create("tester1@test.com", "encoded-password", "tester1"));
+		User tester2 = userRepository.save(User.create("tester2@test.com", "encoded-password", "tester2"));
+		Team team = teamRepository.save(Team.create("t1", null, CATEGORY, tester1));
+
+		TeamApplicationResponse tester2Application = teamApplicationService.createApplication(
+			team.getId(),
+			tester2.getId(),
+			request("join")
+		);
+		teamApplicationService.approveApplication(tester2Application.applicationId(), tester1.getId());
+		TeamMember tester2Member = teamMemberRepository.findActiveMemberByTeamIdAndUserId(
+			team.getId(),
+			tester2.getId()
+		).orElseThrow();
+		teamMemberService.delegateOwner(team.getId(), tester1.getId(), tester2Member.getId());
+		teamMemberService.leaveTeam(team.getId(), tester1.getId());
+
+		return new ReapplyFixture(tester1, tester2, team);
+	}
+
+	private TeamApplicationCreateRequest request(String message) {
+		return new TeamApplicationCreateRequest(message);
+	}
+
+	private record ReapplyFixture(User tester1, User tester2, Team team) {
+	}
+}

--- a/src/test/java/com/neomango/team/service/TeamApplicationServiceTest.java
+++ b/src/test/java/com/neomango/team/service/TeamApplicationServiceTest.java
@@ -348,11 +348,11 @@ class TeamApplicationServiceTest {
 		when(teamApplicationRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(application));
 		when(teamMemberRepository.findByTeamIdAndRole(TEAM_ID, TeamMemberRole.OWNER))
 			.thenReturn(Optional.of(team.getMembers().get(0)));
-		when(teamMemberRepository.existsByTeamIdAndUserId(TEAM_ID, APPLICANT_ID)).thenReturn(false);
 		when(teamMemberRepository.existsByTeamIdAndUserIdAndStatus(TEAM_ID, APPLICANT_ID, TeamMemberStatus.ACTIVE))
 			.thenReturn(false);
 		when(teamMemberRepository.existsActiveMemberByUserIdAndTeamCategory(APPLICANT_ID, "FUTSAL"))
 			.thenReturn(false);
+		when(teamMemberRepository.findByTeamIdAndUserId(TEAM_ID, APPLICANT_ID)).thenReturn(Optional.empty());
 		when(teamApplicationRepository.findOtherPendingApplicationsInSameCategory(100L, APPLICANT_ID, "FUTSAL"))
 			.thenReturn(List.of());
 
@@ -424,11 +424,11 @@ class TeamApplicationServiceTest {
 		when(teamApplicationRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(application));
 		when(teamMemberRepository.findByTeamIdAndRole(TEAM_ID, TeamMemberRole.OWNER))
 			.thenReturn(Optional.of(team.getMembers().get(0)));
-		when(teamMemberRepository.existsByTeamIdAndUserId(TEAM_ID, APPLICANT_ID)).thenReturn(false);
 		when(teamMemberRepository.existsByTeamIdAndUserIdAndStatus(TEAM_ID, APPLICANT_ID, TeamMemberStatus.ACTIVE))
 			.thenReturn(false);
 		when(teamMemberRepository.existsActiveMemberByUserIdAndTeamCategory(APPLICANT_ID, "FUTSAL"))
 			.thenReturn(false);
+		when(teamMemberRepository.findByTeamIdAndUserId(TEAM_ID, APPLICANT_ID)).thenReturn(Optional.empty());
 		when(teamApplicationRepository.findOtherPendingApplicationsInSameCategory(100L, APPLICANT_ID, "FUTSAL"))
 			.thenReturn(List.of(otherApplication));
 


### PR DESCRIPTION
## 📝 개요
- **작업 유형**: 버그 수정
- **관련 이슈**: #31 
- **요약**: 탈퇴한 팀원이 같은 팀에 재가입 신청 후 승인받을 때, 기존 INACTIVE TeamMember 이력을 ACTIVE/MEMBER로 재활성화하도록 수정


## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🚀 주요 변경 사항
- ACTIVE 멤버만 중복 멤버로 판단하도록 승인 로직 수정
- INACTIVE TeamMember 이력이 있으면 새 row 생성 대신 재활성화
- 탈퇴자 재가입 신청/승인/거절 관련 테스트 추가
- TeamMember 중복 row 생성 방지 검증 추가