### PR TITLE
feat: 게시글 및 댓글 CRUD API 구현

### DIFF
--- a/src/main/java/com/neomango/comment/controller/CommentController.java
+++ b/src/main/java/com/neomango/comment/controller/CommentController.java
@@ -1,0 +1,82 @@
+package com.neomango.comment.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.neomango.comment.dto.CommentCreateRequest;
+import com.neomango.comment.dto.CommentResponse;
+import com.neomango.comment.dto.CommentUpdateRequest;
+import com.neomango.comment.service.CommentService;
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+import com.neomango.global.response.ApiResponse;
+import com.neomango.global.security.AuthenticatedUser;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+	private final CommentService commentService;
+
+	@PostMapping("/api/posts/{postId}/comments")
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResponse<CommentResponse> createComment(
+		@AuthenticationPrincipal AuthenticatedUser currentUser,
+		@PathVariable Long postId,
+		@Valid @RequestBody CommentCreateRequest request
+	) {
+		if (currentUser == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		return ApiResponse.success(commentService.createComment(postId, currentUser.userId(), request));
+	}
+
+	@GetMapping("/api/posts/{postId}/comments")
+	public ApiResponse<Page<CommentResponse>> getComments(
+		@PathVariable Long postId,
+		@PageableDefault(size = 20) Pageable pageable
+	) {
+		return ApiResponse.success(commentService.getComments(postId, pageable));
+	}
+
+	@PatchMapping("/api/comments/{commentId}")
+	public ApiResponse<CommentResponse> updateComment(
+		@AuthenticationPrincipal AuthenticatedUser currentUser,
+		@PathVariable Long commentId,
+		@Valid @RequestBody CommentUpdateRequest request
+	) {
+		if (currentUser == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		return ApiResponse.success(commentService.updateComment(commentId, currentUser.userId(), request));
+	}
+
+	@DeleteMapping("/api/comments/{commentId}")
+	public ApiResponse<Void> deleteComment(
+		@AuthenticationPrincipal AuthenticatedUser currentUser,
+		@PathVariable Long commentId
+	) {
+		if (currentUser == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		commentService.deleteComment(commentId, currentUser.userId());
+		return ApiResponse.successWithoutData();
+	}
+}

--- a/src/main/java/com/neomango/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/neomango/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,11 @@
+package com.neomango.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CommentCreateRequest(
+	@NotBlank
+	@Size(max = 1000)
+	String content
+) {
+}

--- a/src/main/java/com/neomango/comment/dto/CommentResponse.java
+++ b/src/main/java/com/neomango/comment/dto/CommentResponse.java
@@ -1,0 +1,35 @@
+package com.neomango.comment.dto;
+
+import java.time.LocalDateTime;
+
+import com.neomango.comment.entity.Comment;
+import com.neomango.user.entity.User;
+import com.neomango.user.entity.UserStatus;
+
+public record CommentResponse(
+	Long id,
+	String content,
+	String authorNickname,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
+
+	private static final String DELETED_USER_NICKNAME = "탈퇴한 사용자";
+
+	public static CommentResponse from(Comment comment) {
+		return new CommentResponse(
+			comment.getId(),
+			comment.getContent(),
+			authorNickname(comment.getAuthor()),
+			comment.getCreatedAt(),
+			comment.getUpdatedAt()
+		);
+	}
+
+	private static String authorNickname(User author) {
+		if (author.getStatus() == UserStatus.DELETED) {
+			return DELETED_USER_NICKNAME;
+		}
+		return author.getNickname();
+	}
+}

--- a/src/main/java/com/neomango/comment/dto/CommentUpdateRequest.java
+++ b/src/main/java/com/neomango/comment/dto/CommentUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.neomango.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CommentUpdateRequest(
+	@NotBlank
+	@Size(max = 1000)
+	String content
+) {
+}

--- a/src/main/java/com/neomango/comment/entity/Comment.java
+++ b/src/main/java/com/neomango/comment/entity/Comment.java
@@ -1,0 +1,92 @@
+package com.neomango.comment.entity;
+
+import java.time.LocalDateTime;
+
+import com.neomango.comment.exception.CommentAccessDeniedException;
+import com.neomango.comment.exception.CommentNotFoundException;
+import com.neomango.global.entity.BaseTimeEntity;
+import com.neomango.post.entity.Post;
+import com.neomango.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "comments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "post_id", nullable = false)
+	private Post post;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "author_id", nullable = false)
+	private User author;
+
+	@Column(nullable = false, length = 1000)
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private CommentStatus status;
+
+	private LocalDateTime deletedAt;
+
+	private Comment(Post post, User author, String content) {
+		this.post = post;
+		this.author = author;
+		this.content = content;
+		this.status = CommentStatus.ACTIVE;
+	}
+
+	public static Comment create(Post post, User author, String content) {
+		return new Comment(post, author, content);
+	}
+
+	public void update(String content, Long requesterId) {
+		validateNotDeleted();
+		validateAuthor(requesterId);
+		this.content = content;
+	}
+
+	public void softDelete(Long requesterId) {
+		validateNotDeleted();
+		validateAuthor(requesterId);
+		this.status = CommentStatus.DELETED;
+		this.deletedAt = LocalDateTime.now();
+	}
+
+	public boolean isDeleted() {
+		return this.status == CommentStatus.DELETED;
+	}
+
+	public void validateAuthor(Long requesterId) {
+		if (!this.author.getId().equals(requesterId)) {
+			throw new CommentAccessDeniedException();
+		}
+	}
+
+	public void validateNotDeleted() {
+		if (isDeleted()) {
+			throw new CommentNotFoundException();
+		}
+	}
+}

--- a/src/main/java/com/neomango/comment/entity/CommentStatus.java
+++ b/src/main/java/com/neomango/comment/entity/CommentStatus.java
@@ -1,0 +1,6 @@
+package com.neomango.comment.entity;
+
+public enum CommentStatus {
+	ACTIVE,
+	DELETED
+}

--- a/src/main/java/com/neomango/comment/exception/CommentAccessDeniedException.java
+++ b/src/main/java/com/neomango/comment/exception/CommentAccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.neomango.comment.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class CommentAccessDeniedException extends BusinessException {
+
+	public CommentAccessDeniedException() {
+		super(ErrorCode.COMMENT_ACCESS_DENIED);
+	}
+}

--- a/src/main/java/com/neomango/comment/exception/CommentNotFoundException.java
+++ b/src/main/java/com/neomango/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,11 @@
+package com.neomango.comment.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class CommentNotFoundException extends BusinessException {
+
+	public CommentNotFoundException() {
+		super(ErrorCode.COMMENT_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/neomango/comment/repository/CommentRepository.java
+++ b/src/main/java/com/neomango/comment/repository/CommentRepository.java
@@ -1,0 +1,15 @@
+package com.neomango.comment.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.neomango.comment.entity.Comment;
+import com.neomango.comment.entity.CommentStatus;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+	@EntityGraph(attributePaths = "author")
+	Page<Comment> findByPostIdAndStatus(Long postId, CommentStatus status, Pageable pageable);
+}

--- a/src/main/java/com/neomango/comment/service/CommentService.java
+++ b/src/main/java/com/neomango/comment/service/CommentService.java
@@ -1,0 +1,98 @@
+package com.neomango.comment.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.neomango.comment.dto.CommentCreateRequest;
+import com.neomango.comment.dto.CommentResponse;
+import com.neomango.comment.dto.CommentUpdateRequest;
+import com.neomango.comment.entity.Comment;
+import com.neomango.comment.entity.CommentStatus;
+import com.neomango.comment.exception.CommentNotFoundException;
+import com.neomango.comment.repository.CommentRepository;
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+import com.neomango.post.entity.Post;
+import com.neomango.post.entity.PostStatus;
+import com.neomango.post.exception.PostNotFoundException;
+import com.neomango.post.repository.PostRepository;
+import com.neomango.user.entity.User;
+import com.neomango.user.entity.UserStatus;
+import com.neomango.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+
+	private final CommentRepository commentRepository;
+	private final PostRepository postRepository;
+	private final UserRepository userRepository;
+
+	public CommentResponse createComment(Long postId, Long authorId, CommentCreateRequest request) {
+		if (authorId == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		Post post = postRepository.findByIdAndStatus(postId, PostStatus.ACTIVE)
+			.orElseThrow(PostNotFoundException::new);
+		User author = userRepository.findById(authorId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+		validateActiveUser(author);
+
+		Comment comment = Comment.create(post, author, request.content());
+		return CommentResponse.from(commentRepository.save(comment));
+	}
+
+	@Transactional(readOnly = true)
+	public Page<CommentResponse> getComments(Long postId, Pageable pageable) {
+		if (!postRepository.existsByIdAndStatus(postId, PostStatus.ACTIVE)) {
+			throw new PostNotFoundException();
+		}
+
+		Pageable oldestPageable = PageRequest.of(
+			pageable.getPageNumber(),
+			pageable.getPageSize(),
+			Sort.by(Sort.Direction.ASC, "createdAt", "id")
+		);
+
+		return commentRepository.findByPostIdAndStatus(postId, CommentStatus.ACTIVE, oldestPageable)
+			.map(CommentResponse::from);
+	}
+
+	public CommentResponse updateComment(Long commentId, Long requesterId, CommentUpdateRequest request) {
+		if (requesterId == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(CommentNotFoundException::new);
+		comment.getPost().validateNotDeleted();
+		comment.update(request.content(), requesterId);
+
+		return CommentResponse.from(comment);
+	}
+
+	public void deleteComment(Long commentId, Long requesterId) {
+		if (requesterId == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(CommentNotFoundException::new);
+		comment.getPost().validateNotDeleted();
+		comment.softDelete(requesterId);
+	}
+
+	private void validateActiveUser(User user) {
+		if (user.getStatus() != UserStatus.ACTIVE) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+	}
+}

--- a/src/main/java/com/neomango/global/config/SecurityConfig.java
+++ b/src/main/java/com/neomango/global/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
 				.requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/reissue").permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/teams", "/api/teams/*").permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/categories/*/posts", "/api/posts/*").permitAll()
+				.requestMatchers(HttpMethod.GET, "/api/posts/*/comments").permitAll()
 				.requestMatchers("/error").permitAll()
 				.anyRequest().authenticated()
 			)

--- a/src/main/java/com/neomango/global/config/SecurityConfig.java
+++ b/src/main/java/com/neomango/global/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/reissue").permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/teams", "/api/teams/*").permitAll()
+				.requestMatchers(HttpMethod.GET, "/api/categories/*/posts", "/api/posts/*").permitAll()
 				.requestMatchers("/error").permitAll()
 				.anyRequest().authenticated()
 			)

--- a/src/main/java/com/neomango/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/neomango/global/entity/BaseTimeEntity.java
@@ -1,0 +1,33 @@
+package com.neomango.global.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseTimeEntity {
+
+	@Column(nullable = false)
+	private LocalDateTime createdAt;
+
+	@Column(nullable = false)
+	private LocalDateTime updatedAt;
+
+	@PrePersist
+	void prePersist() {
+		LocalDateTime now = LocalDateTime.now();
+		this.createdAt = now;
+		this.updatedAt = now;
+	}
+
+	@PreUpdate
+	void preUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/neomango/global/exception/ErrorCode.java
+++ b/src/main/java/com/neomango/global/exception/ErrorCode.java
@@ -35,12 +35,16 @@ public enum ErrorCode {
 	INVALID_OWNER_DELEGATION_TARGET(HttpStatus.CONFLICT, "T011", "위임 대상은 같은 팀의 활성 멤버여야 합니다."),
 	CANNOT_KICK_OWNER(HttpStatus.CONFLICT, "T012", "팀 주장은 강퇴할 수 없습니다."),
 	TEAM_OWNER_INVARIANT_VIOLATED(HttpStatus.CONFLICT, "T013", "활성 팀 주장은 반드시 한 명이어야 합니다."),
+
 	TEAM_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "TA001", "존재하지 않는 가입 신청입니다."),
 	DUPLICATE_PENDING_TEAM_APPLICATION(HttpStatus.CONFLICT, "TA002", "이미 가입 신청한 팀입니다."),
 	INVALID_TEAM_APPLICATION_STATUS(HttpStatus.CONFLICT, "TA003", "처리할 수 없는 가입 신청 상태입니다."),
 	TEAM_APPLICATION_CANCEL_FORBIDDEN(HttpStatus.FORBIDDEN, "TA004", "본인의 가입 신청만 취소할 수 있습니다."),
 	ONLY_PENDING_TEAM_APPLICATION_CANCELABLE(HttpStatus.CONFLICT, "TA005", "대기 중인 가입 신청만 취소할 수 있습니다."),
-	TEAM_APPLICATION_LIST_OWNER_REQUIRED(HttpStatus.FORBIDDEN, "TA006", "팀 주장만 가입 신청 목록을 조회할 수 있습니다.");
+	TEAM_APPLICATION_LIST_OWNER_REQUIRED(HttpStatus.FORBIDDEN, "TA006", "팀 주장만 가입 신청 목록을 조회할 수 있습니다."),
+
+	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "존재하지 않는 게시글입니다."),
+	POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "P002", "작성자만 수정 또는 삭제할 수 있습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/neomango/global/exception/ErrorCode.java
+++ b/src/main/java/com/neomango/global/exception/ErrorCode.java
@@ -44,7 +44,10 @@ public enum ErrorCode {
 	TEAM_APPLICATION_LIST_OWNER_REQUIRED(HttpStatus.FORBIDDEN, "TA006", "팀 주장만 가입 신청 목록을 조회할 수 있습니다."),
 
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "존재하지 않는 게시글입니다."),
-	POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "P002", "작성자만 수정 또는 삭제할 수 있습니다.");
+	POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "P002", "작성자만 수정 또는 삭제할 수 있습니다."),
+
+	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "C001", "존재하지 않는 댓글입니다."),
+	COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C002", "작성자만 댓글을 수정 또는 삭제할 수 있습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/neomango/post/controller/PostController.java
+++ b/src/main/java/com/neomango/post/controller/PostController.java
@@ -1,0 +1,88 @@
+package com.neomango.post.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+import com.neomango.global.response.ApiResponse;
+import com.neomango.global.security.AuthenticatedUser;
+import com.neomango.post.dto.PostCreateRequest;
+import com.neomango.post.dto.PostResponse;
+import com.neomango.post.dto.PostSummaryResponse;
+import com.neomango.post.dto.PostUpdateRequest;
+import com.neomango.post.service.PostService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+
+	private final PostService postService;
+
+	@PostMapping("/api/categories/{category}/posts")
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResponse<PostResponse> createPost(
+		@AuthenticationPrincipal AuthenticatedUser currentUser,
+		@PathVariable String category,
+		@Valid @RequestBody PostCreateRequest request
+	) {
+		if (currentUser == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		return ApiResponse.success(postService.createPost(currentUser.userId(), category, request));
+	}
+
+	@GetMapping("/api/categories/{category}/posts")
+	public ApiResponse<Page<PostSummaryResponse>> getPosts(
+		@PathVariable String category,
+		@PageableDefault(size = 20) Pageable pageable
+	) {
+		return ApiResponse.success(postService.getPosts(category, pageable));
+	}
+
+	@GetMapping("/api/posts/{postId}")
+	public ApiResponse<PostResponse> getPost(@PathVariable Long postId) {
+		return ApiResponse.success(postService.getPost(postId));
+	}
+
+	@PatchMapping("/api/posts/{postId}")
+	public ApiResponse<PostResponse> updatePost(
+		@AuthenticationPrincipal AuthenticatedUser currentUser,
+		@PathVariable Long postId,
+		@Valid @RequestBody PostUpdateRequest request
+	) {
+		if (currentUser == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		return ApiResponse.success(postService.updatePost(postId, currentUser.userId(), request));
+	}
+
+	@DeleteMapping("/api/posts/{postId}")
+	public ApiResponse<Void> deletePost(
+		@AuthenticationPrincipal AuthenticatedUser currentUser,
+		@PathVariable Long postId
+	) {
+		if (currentUser == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		postService.deletePost(postId, currentUser.userId());
+		return ApiResponse.successWithoutData();
+	}
+}

--- a/src/main/java/com/neomango/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/neomango/post/dto/PostCreateRequest.java
@@ -1,0 +1,15 @@
+package com.neomango.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PostCreateRequest(
+	@NotBlank
+	@Size(max = 100)
+	String title,
+
+	@NotBlank
+	@Size(max = 5000)
+	String content
+) {
+}

--- a/src/main/java/com/neomango/post/dto/PostResponse.java
+++ b/src/main/java/com/neomango/post/dto/PostResponse.java
@@ -1,0 +1,39 @@
+package com.neomango.post.dto;
+
+import java.time.LocalDateTime;
+
+import com.neomango.post.entity.Post;
+import com.neomango.user.entity.User;
+import com.neomango.user.entity.UserStatus;
+
+public record PostResponse(
+	Long id,
+	String category,
+	String title,
+	String content,
+	String authorNickname,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
+
+	private static final String DELETED_USER_NICKNAME = "탈퇴한 사용자";
+
+	public static PostResponse from(Post post) {
+		return new PostResponse(
+			post.getId(),
+			post.getCategory(),
+			post.getTitle(),
+			post.getContent(),
+			authorNickname(post.getAuthor()),
+			post.getCreatedAt(),
+			post.getUpdatedAt()
+		);
+	}
+
+	private static String authorNickname(User author) {
+		if (author.getStatus() == UserStatus.DELETED) {
+			return DELETED_USER_NICKNAME;
+		}
+		return author.getNickname();
+	}
+}

--- a/src/main/java/com/neomango/post/dto/PostSummaryResponse.java
+++ b/src/main/java/com/neomango/post/dto/PostSummaryResponse.java
@@ -1,0 +1,35 @@
+package com.neomango.post.dto;
+
+import java.time.LocalDateTime;
+
+import com.neomango.post.entity.Post;
+import com.neomango.user.entity.User;
+import com.neomango.user.entity.UserStatus;
+
+public record PostSummaryResponse(
+	Long id,
+	String category,
+	String title,
+	String authorNickname,
+	LocalDateTime createdAt
+) {
+
+	private static final String DELETED_USER_NICKNAME = "탈퇴한 사용자";
+
+	public static PostSummaryResponse from(Post post) {
+		return new PostSummaryResponse(
+			post.getId(),
+			post.getCategory(),
+			post.getTitle(),
+			authorNickname(post.getAuthor()),
+			post.getCreatedAt()
+		);
+	}
+
+	private static String authorNickname(User author) {
+		if (author.getStatus() == UserStatus.DELETED) {
+			return DELETED_USER_NICKNAME;
+		}
+		return author.getNickname();
+	}
+}

--- a/src/main/java/com/neomango/post/dto/PostUpdateRequest.java
+++ b/src/main/java/com/neomango/post/dto/PostUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.neomango.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PostUpdateRequest(
+	@NotBlank
+	@Size(max = 100)
+	String title,
+
+	@NotBlank
+	@Size(max = 5000)
+	String content
+) {
+}

--- a/src/main/java/com/neomango/post/entity/Post.java
+++ b/src/main/java/com/neomango/post/entity/Post.java
@@ -1,0 +1,114 @@
+package com.neomango.post.entity;
+
+import java.time.LocalDateTime;
+
+import com.neomango.post.exception.PostAccessDeniedException;
+import com.neomango.post.exception.PostNotFoundException;
+import com.neomango.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "posts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, length = 50)
+	private String category;
+
+	@Column(nullable = false, length = 100)
+	private String title;
+
+	@Column(nullable = false, length = 5000)
+	private String content;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "author_id", nullable = false)
+	private User author;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private PostStatus status;
+
+	@Column(nullable = false)
+	private LocalDateTime createdAt;
+
+	@Column(nullable = false)
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	private Post(String category, String title, String content, User author) {
+		this.category = category;
+		this.title = title;
+		this.content = content;
+		this.author = author;
+		this.status = PostStatus.ACTIVE;
+	}
+
+	public static Post create(String category, String title, String content, User author) {
+		return new Post(category, title, content, author);
+	}
+
+	public void update(String title, String content, Long requesterId) {
+		validateNotDeleted();
+		validateAuthor(requesterId);
+		this.title = title;
+		this.content = content;
+	}
+
+	public void softDelete(Long requesterId) {
+		validateNotDeleted();
+		validateAuthor(requesterId);
+		this.status = PostStatus.DELETED;
+		this.deletedAt = LocalDateTime.now();
+	}
+
+	public boolean isDeleted() {
+		return this.status == PostStatus.DELETED;
+	}
+
+	public void validateAuthor(Long requesterId) {
+		if (!this.author.getId().equals(requesterId)) {
+			throw new PostAccessDeniedException();
+		}
+	}
+
+	public void validateNotDeleted() {
+		if (isDeleted()) {
+			throw new PostNotFoundException();
+		}
+	}
+
+	@PrePersist
+	void prePersist() {
+		LocalDateTime now = LocalDateTime.now();
+		this.createdAt = now;
+		this.updatedAt = now;
+	}
+
+	@PreUpdate
+	void preUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/neomango/post/entity/PostStatus.java
+++ b/src/main/java/com/neomango/post/entity/PostStatus.java
@@ -1,0 +1,6 @@
+package com.neomango.post.entity;
+
+public enum PostStatus {
+	ACTIVE,
+	DELETED
+}

--- a/src/main/java/com/neomango/post/exception/PostAccessDeniedException.java
+++ b/src/main/java/com/neomango/post/exception/PostAccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.neomango.post.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class PostAccessDeniedException extends BusinessException {
+
+	public PostAccessDeniedException() {
+		super(ErrorCode.POST_ACCESS_DENIED);
+	}
+}

--- a/src/main/java/com/neomango/post/exception/PostNotFoundException.java
+++ b/src/main/java/com/neomango/post/exception/PostNotFoundException.java
@@ -1,0 +1,11 @@
+package com.neomango.post.exception;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+
+public class PostNotFoundException extends BusinessException {
+
+	public PostNotFoundException() {
+		super(ErrorCode.POST_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/neomango/post/repository/PostRepository.java
+++ b/src/main/java/com/neomango/post/repository/PostRepository.java
@@ -1,0 +1,20 @@
+package com.neomango.post.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.neomango.post.entity.Post;
+import com.neomango.post.entity.PostStatus;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+	@EntityGraph(attributePaths = "author")
+	Page<Post> findByCategoryAndStatus(String category, PostStatus status, Pageable pageable);
+
+	@EntityGraph(attributePaths = "author")
+	Optional<Post> findByIdAndStatus(Long id, PostStatus status);
+}

--- a/src/main/java/com/neomango/post/repository/PostRepository.java
+++ b/src/main/java/com/neomango/post/repository/PostRepository.java
@@ -17,4 +17,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
 	@EntityGraph(attributePaths = "author")
 	Optional<Post> findByIdAndStatus(Long id, PostStatus status);
+
+	boolean existsByIdAndStatus(Long id, PostStatus status);
 }

--- a/src/main/java/com/neomango/post/service/PostService.java
+++ b/src/main/java/com/neomango/post/service/PostService.java
@@ -1,0 +1,103 @@
+package com.neomango.post.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.neomango.global.exception.BusinessException;
+import com.neomango.global.exception.ErrorCode;
+import com.neomango.post.dto.PostCreateRequest;
+import com.neomango.post.dto.PostResponse;
+import com.neomango.post.dto.PostSummaryResponse;
+import com.neomango.post.dto.PostUpdateRequest;
+import com.neomango.post.entity.Post;
+import com.neomango.post.entity.PostStatus;
+import com.neomango.post.exception.PostNotFoundException;
+import com.neomango.post.repository.PostRepository;
+import com.neomango.user.entity.User;
+import com.neomango.user.entity.UserStatus;
+import com.neomango.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostService {
+
+	private final PostRepository postRepository;
+	private final UserRepository userRepository;
+
+	public PostResponse createPost(Long authorId, String category, PostCreateRequest request) {
+		if (authorId == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		User author = userRepository.findById(authorId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+		validateActiveUser(author);
+
+		Post post = Post.create(normalizeCategory(category), request.title(), request.content(), author);
+		return PostResponse.from(postRepository.save(post));
+	}
+
+	@Transactional(readOnly = true)
+	public Page<PostSummaryResponse> getPosts(String category, Pageable pageable) {
+		Pageable latestPageable = PageRequest.of(
+			pageable.getPageNumber(),
+			pageable.getPageSize(),
+			Sort.by(Sort.Direction.DESC, "createdAt", "id")
+		);
+
+		return postRepository.findByCategoryAndStatus(normalizeCategory(category), PostStatus.ACTIVE, latestPageable)
+			.map(PostSummaryResponse::from);
+	}
+
+	@Transactional(readOnly = true)
+	public PostResponse getPost(Long postId) {
+		Post post = postRepository.findByIdAndStatus(postId, PostStatus.ACTIVE)
+			.orElseThrow(PostNotFoundException::new);
+
+		return PostResponse.from(post);
+	}
+
+	public PostResponse updatePost(Long postId, Long requesterId, PostUpdateRequest request) {
+		if (requesterId == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		Post post = postRepository.findById(postId)
+			.orElseThrow(PostNotFoundException::new);
+		post.update(request.title(), request.content(), requesterId);
+
+		return PostResponse.from(post);
+	}
+
+	public void deletePost(Long postId, Long requesterId) {
+		if (requesterId == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		Post post = postRepository.findById(postId)
+			.orElseThrow(PostNotFoundException::new);
+		post.softDelete(requesterId);
+	}
+
+	private void validateActiveUser(User user) {
+		if (user.getStatus() != UserStatus.ACTIVE) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+	}
+
+	private String normalizeCategory(String category) {
+		if (!StringUtils.hasText(category)) {
+			throw new BusinessException(ErrorCode.INVALID_REQUEST);
+		}
+		// TODO: Team/Post category 문자열 표준화를 위해 enum 또는 Category 테이블 분리를 검토한다.
+		return category.trim();
+	}
+}

--- a/src/test/java/com/neomango/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/neomango/comment/controller/CommentControllerTest.java
@@ -1,0 +1,313 @@
+package com.neomango.comment.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.neomango.auth.jwt.JwtTokenProvider;
+import com.neomango.comment.dto.CommentCreateRequest;
+import com.neomango.comment.dto.CommentUpdateRequest;
+import com.neomango.comment.entity.Comment;
+import com.neomango.comment.entity.CommentStatus;
+import com.neomango.comment.repository.CommentRepository;
+import com.neomango.post.entity.Post;
+import com.neomango.post.repository.PostRepository;
+import com.neomango.team.repository.TeamApplicationRepository;
+import com.neomango.team.repository.TeamMemberRepository;
+import com.neomango.team.repository.TeamRepository;
+import com.neomango.team.repository.UserCategoryMembershipRepository;
+import com.neomango.user.entity.User;
+import com.neomango.user.entity.UserRole;
+import com.neomango.user.repository.UserRepository;
+
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest
+class CommentControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Autowired
+	private CommentRepository commentRepository;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private TeamApplicationRepository teamApplicationRepository;
+
+	@Autowired
+	private UserCategoryMembershipRepository userCategoryMembershipRepository;
+
+	@Autowired
+	private TeamMemberRepository teamMemberRepository;
+
+	@Autowired
+	private TeamRepository teamRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@BeforeEach
+	void setUp() {
+		deleteAll();
+	}
+
+	@AfterEach
+	void tearDown() {
+		deleteAll();
+	}
+
+	@Test
+	void createCommentReturnsCreatedWhenAuthenticated() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		CommentCreateRequest request = new CommentCreateRequest("comment");
+
+		mockMvc.perform(post("/api/posts/{postId}/comments", post.getId())
+				.header("Authorization", "Bearer " + accessToken(author))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.data.content").value("comment"))
+			.andExpect(jsonPath("$.data.authorNickname").value("author"))
+			.andExpect(jsonPath("$.data.authorId").doesNotExist());
+
+		Comment comment = commentRepository.findAll().get(0);
+		assertThat(comment.getPost().getId()).isEqualTo(post.getId());
+		assertThat(comment.getAuthor().getId()).isEqualTo(author.getId());
+	}
+
+	@Test
+	void createCommentRejectsRequestWithoutAuthentication() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		CommentCreateRequest request = new CommentCreateRequest("comment");
+
+		mockMvc.perform(post("/api/posts/{postId}/comments", post.getId())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void createCommentRejectsMissingPost() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		CommentCreateRequest request = new CommentCreateRequest("comment");
+
+		mockMvc.perform(post("/api/posts/{postId}/comments", 999L)
+				.header("Authorization", "Bearer " + accessToken(author))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("P001"));
+	}
+
+	@Test
+	void createCommentRejectsDeletedPost() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		post.softDelete(author.getId());
+		postRepository.saveAndFlush(post);
+		CommentCreateRequest request = new CommentCreateRequest("comment");
+
+		mockMvc.perform(post("/api/posts/{postId}/comments", post.getId())
+				.header("Authorization", "Bearer " + accessToken(author))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("P001"));
+	}
+
+	@Test
+	void getCommentsReturnsOnlyActiveCommentsInOldestOrder() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		Comment oldComment = commentRepository.save(Comment.create(post, author, "old"));
+		Comment latestComment = commentRepository.save(Comment.create(post, author, "latest"));
+		Comment deletedComment = commentRepository.save(Comment.create(post, author, "deleted"));
+		deletedComment.softDelete(author.getId());
+		commentRepository.saveAndFlush(deletedComment);
+
+		mockMvc.perform(get("/api/posts/{postId}/comments", post.getId())
+				.param("page", "0")
+				.param("size", "10"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.length()").value(2))
+			.andExpect(jsonPath("$.data.content[0].id").value(oldComment.getId()))
+			.andExpect(jsonPath("$.data.content[0].content").value("old"))
+			.andExpect(jsonPath("$.data.content[1].id").value(latestComment.getId()))
+			.andExpect(jsonPath("$.data.totalElements").value(2));
+	}
+
+	@Test
+	void getCommentsRejectsDeletedPost() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		post.softDelete(author.getId());
+		postRepository.saveAndFlush(post);
+
+		mockMvc.perform(get("/api/posts/{postId}/comments", post.getId()))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("P001"));
+	}
+
+	@Test
+	void updateCommentSucceedsWhenRequesterIsAuthor() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		Comment comment = commentRepository.save(Comment.create(post, author, "comment"));
+		CommentUpdateRequest request = new CommentUpdateRequest("updated");
+
+		mockMvc.perform(patch("/api/comments/{commentId}", comment.getId())
+				.header("Authorization", "Bearer " + accessToken(author))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content").value("updated"));
+
+		Comment updatedComment = commentRepository.findById(comment.getId()).orElseThrow();
+		assertThat(updatedComment.getContent()).isEqualTo("updated");
+	}
+
+	@Test
+	void updateCommentRejectsRequesterWhoIsNotAuthor() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		User other = userRepository.save(User.create("other@test.com", "encoded-password", "other"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		Comment comment = commentRepository.save(Comment.create(post, author, "comment"));
+		CommentUpdateRequest request = new CommentUpdateRequest("updated");
+
+		mockMvc.perform(patch("/api/comments/{commentId}", comment.getId())
+				.header("Authorization", "Bearer " + accessToken(other))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("C002"));
+	}
+
+	@Test
+	void deleteCommentSoftDeletesWhenRequesterIsAuthor() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		Comment comment = commentRepository.save(Comment.create(post, author, "comment"));
+
+		mockMvc.perform(delete("/api/comments/{commentId}", comment.getId())
+				.header("Authorization", "Bearer " + accessToken(author)))
+			.andExpect(status().isOk());
+
+		Comment deletedComment = commentRepository.findById(comment.getId()).orElseThrow();
+		assertThat(deletedComment.getStatus()).isEqualTo(CommentStatus.DELETED);
+		assertThat(deletedComment.getDeletedAt()).isNotNull();
+
+		mockMvc.perform(get("/api/posts/{postId}/comments", post.getId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.totalElements").value(0));
+	}
+
+	@Test
+	void deleteCommentRejectsRequesterWhoIsNotAuthor() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		User other = userRepository.save(User.create("other@test.com", "encoded-password", "other"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		Comment comment = commentRepository.save(Comment.create(post, author, "comment"));
+
+		mockMvc.perform(delete("/api/comments/{commentId}", comment.getId())
+				.header("Authorization", "Bearer " + accessToken(other)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("C002"));
+	}
+
+	@Test
+	void createCommentRejectsBlankContent() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		CommentCreateRequest request = new CommentCreateRequest(" ");
+
+		mockMvc.perform(post("/api/posts/{postId}/comments", post.getId())
+				.header("Authorization", "Bearer " + accessToken(author))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("G001"));
+	}
+
+	@Test
+	void createCommentRejectsTooLongContent() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		CommentCreateRequest request = new CommentCreateRequest("a".repeat(1001));
+
+		mockMvc.perform(post("/api/posts/{postId}/comments", post.getId())
+				.header("Authorization", "Bearer " + accessToken(author))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("G001"));
+	}
+
+	@Test
+	void getCommentsShowsDeletedUserNickname() throws Exception {
+		User author = userRepository.save(User.create("deleted-author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		commentRepository.save(Comment.create(post, author, "comment"));
+		author.softDelete();
+		userRepository.saveAndFlush(author);
+
+		mockMvc.perform(get("/api/posts/{postId}/comments", post.getId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content[0].authorNickname").value("탈퇴한 사용자"));
+	}
+
+	@Test
+	void getCommentsDoesNotExposeInternalFields() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		commentRepository.save(Comment.create(post, author, "comment"));
+
+		mockMvc.perform(get("/api/posts/{postId}/comments", post.getId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content[0].authorId").doesNotExist())
+			.andExpect(jsonPath("$.data.content[0].post").doesNotExist())
+			.andExpect(jsonPath("$.data.content[0].status").doesNotExist())
+			.andExpect(jsonPath("$.data.content[0].deletedAt").doesNotExist())
+			.andExpect(jsonPath("$.data.content[0].email").doesNotExist())
+			.andExpect(jsonPath("$.data.content[0].role").doesNotExist());
+	}
+
+	private void deleteAll() {
+		teamApplicationRepository.deleteAll();
+		userCategoryMembershipRepository.deleteAll();
+		teamMemberRepository.deleteAll();
+		teamRepository.deleteAll();
+		commentRepository.deleteAll();
+		postRepository.deleteAll();
+		userRepository.deleteAll();
+	}
+
+	private String accessToken(User user) {
+		return jwtTokenProvider.createAccessToken(user.getId(), UserRole.USER);
+	}
+}

--- a/src/test/java/com/neomango/post/controller/PostControllerTest.java
+++ b/src/test/java/com/neomango/post/controller/PostControllerTest.java
@@ -1,0 +1,386 @@
+package com.neomango.post.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.neomango.auth.jwt.JwtTokenProvider;
+import com.neomango.post.dto.PostCreateRequest;
+import com.neomango.post.dto.PostUpdateRequest;
+import com.neomango.post.entity.Post;
+import com.neomango.post.entity.PostStatus;
+import com.neomango.post.repository.PostRepository;
+import com.neomango.team.repository.TeamApplicationRepository;
+import com.neomango.team.repository.TeamMemberRepository;
+import com.neomango.team.repository.TeamRepository;
+import com.neomango.team.repository.UserCategoryMembershipRepository;
+import com.neomango.user.entity.User;
+import com.neomango.user.entity.UserRole;
+import com.neomango.user.repository.UserRepository;
+
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest
+class PostControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private TeamApplicationRepository teamApplicationRepository;
+
+	@Autowired
+	private UserCategoryMembershipRepository userCategoryMembershipRepository;
+
+	@Autowired
+	private TeamMemberRepository teamMemberRepository;
+
+	@Autowired
+	private TeamRepository teamRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@BeforeEach
+	void setUp() {
+		teamApplicationRepository.deleteAll();
+		userCategoryMembershipRepository.deleteAll();
+		teamMemberRepository.deleteAll();
+		teamRepository.deleteAll();
+		postRepository.deleteAll();
+		userRepository.deleteAll();
+	}
+
+	@AfterEach
+	void tearDown() {
+		teamApplicationRepository.deleteAll();
+		userCategoryMembershipRepository.deleteAll();
+		teamMemberRepository.deleteAll();
+		teamRepository.deleteAll();
+		postRepository.deleteAll();
+		userRepository.deleteAll();
+	}
+
+	@Test
+	void createPostReturnsCreatedWhenAuthenticated() throws Exception {
+		User user = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		String accessToken = accessToken(user);
+		PostCreateRequest request = new PostCreateRequest("title", "content");
+
+		mockMvc.perform(post("/api/categories/{category}/posts", "GAME")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.data.category").value("GAME"))
+			.andExpect(jsonPath("$.data.title").value("title"))
+			.andExpect(jsonPath("$.data.content").value("content"))
+			.andExpect(jsonPath("$.data.authorNickname").value("author"));
+
+		Post post = postRepository.findAll().get(0);
+		assertThat(post.getAuthor().getId()).isEqualTo(user.getId());
+	}
+
+	@Test
+	void createPostRejectsRequestWithoutAuthentication() throws Exception {
+		PostCreateRequest request = new PostCreateRequest("title", "content");
+
+		mockMvc.perform(post("/api/categories/{category}/posts", "GAME")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void createPostRejectsBlankTitle() throws Exception {
+		User user = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		PostCreateRequest request = new PostCreateRequest(" ", "content");
+
+		mockMvc.perform(post("/api/categories/{category}/posts", "GAME")
+				.header("Authorization", "Bearer " + accessToken(user))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("G001"));
+	}
+
+	@Test
+	void createPostRejectsBlankContent() throws Exception {
+		User user = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		PostCreateRequest request = new PostCreateRequest("title", " ");
+
+		mockMvc.perform(post("/api/categories/{category}/posts", "GAME")
+				.header("Authorization", "Bearer " + accessToken(user))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("G001"));
+	}
+
+	@Test
+	void createPostRejectsTooLongTitle() throws Exception {
+		User user = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		PostCreateRequest request = new PostCreateRequest("a".repeat(101), "content");
+
+		mockMvc.perform(post("/api/categories/{category}/posts", "GAME")
+				.header("Authorization", "Bearer " + accessToken(user))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("G001"));
+	}
+
+	@Test
+	void createPostRejectsTooLongContent() throws Exception {
+		User user = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		PostCreateRequest request = new PostCreateRequest("title", "a".repeat(5001));
+
+		mockMvc.perform(post("/api/categories/{category}/posts", "GAME")
+				.header("Authorization", "Bearer " + accessToken(user))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("G001"));
+	}
+
+	@Test
+	void getPostsReturnsOnlyActivePostsInCategoryWithPagingAndLatestOrder() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post oldPost = postRepository.save(Post.create("GAME", "old", "old content", author));
+		Post latestPost = postRepository.save(Post.create("GAME", "latest", "latest content", author));
+		Post otherCategoryPost = postRepository.save(Post.create("SPORTS", "sports", "sports content", author));
+		Post deletedPost = postRepository.save(Post.create("GAME", "deleted", "deleted content", author));
+		deletedPost.softDelete(author.getId());
+		postRepository.saveAndFlush(deletedPost);
+
+		mockMvc.perform(get("/api/categories/{category}/posts", "GAME")
+				.param("page", "0")
+				.param("size", "1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.length()").value(1))
+			.andExpect(jsonPath("$.data.content[0].id").value(latestPost.getId()))
+			.andExpect(jsonPath("$.data.content[0].title").value("latest"))
+			.andExpect(jsonPath("$.data.content[0].category").value("GAME"))
+			.andExpect(jsonPath("$.data.content[0].authorNickname").value("author"))
+			.andExpect(jsonPath("$.data.content[0].content").doesNotExist())
+			.andExpect(jsonPath("$.data.content[0].authorId").doesNotExist())
+			.andExpect(jsonPath("$.data.totalElements").value(2));
+
+		assertThat(oldPost.getId()).isNotEqualTo(latestPost.getId());
+		assertThat(otherCategoryPost.getCategory()).isEqualTo("SPORTS");
+	}
+
+	@Test
+	void getPostsShowsDeletedUserNickname() throws Exception {
+		User author = userRepository.save(User.create("deleted-author@test.com", "encoded-password", "author"));
+		postRepository.save(Post.create("GAME", "title", "content", author));
+		author.softDelete();
+		userRepository.saveAndFlush(author);
+
+		mockMvc.perform(get("/api/categories/{category}/posts", "GAME"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content[0].authorNickname").value("탈퇴한 사용자"));
+	}
+
+	@Test
+	void getPostReturnsActivePostDetailWithoutAuthentication() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+
+		mockMvc.perform(get("/api/posts/{postId}", post.getId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.id").value(post.getId()))
+			.andExpect(jsonPath("$.data.title").value("title"))
+			.andExpect(jsonPath("$.data.content").value("content"))
+			.andExpect(jsonPath("$.data.category").value("GAME"))
+			.andExpect(jsonPath("$.data.authorNickname").value("author"))
+			.andExpect(jsonPath("$.data.authorId").doesNotExist())
+			.andExpect(jsonPath("$.data.email").doesNotExist())
+			.andExpect(jsonPath("$.data.role").doesNotExist())
+			.andExpect(jsonPath("$.data.status").doesNotExist())
+			.andExpect(jsonPath("$.data.createdAt").exists())
+			.andExpect(jsonPath("$.data.updatedAt").exists());
+	}
+
+	@Test
+	void getPostRejectsDeletedPost() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		post.softDelete(author.getId());
+		postRepository.saveAndFlush(post);
+
+		mockMvc.perform(get("/api/posts/{postId}", post.getId()))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("P001"));
+	}
+
+	@Test
+	void getPostShowsDeletedUserNickname() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		author.softDelete();
+		userRepository.saveAndFlush(author);
+
+		mockMvc.perform(get("/api/posts/{postId}", post.getId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.authorNickname").value("탈퇴한 사용자"));
+	}
+
+	@Test
+	void updatePostSucceedsWhenRequesterIsAuthor() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		PostUpdateRequest request = new PostUpdateRequest("updated", "updated content");
+
+		mockMvc.perform(patch("/api/posts/{postId}", post.getId())
+				.header("Authorization", "Bearer " + accessToken(author))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.title").value("updated"))
+			.andExpect(jsonPath("$.data.content").value("updated content"));
+
+		Post updatedPost = postRepository.findById(post.getId()).orElseThrow();
+		assertThat(updatedPost.getTitle()).isEqualTo("updated");
+		assertThat(updatedPost.getContent()).isEqualTo("updated content");
+	}
+
+	@Test
+	void updatePostRejectsRequesterWhoIsNotAuthor() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		User other = userRepository.save(User.create("other@test.com", "encoded-password", "other"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		PostUpdateRequest request = new PostUpdateRequest("updated", "updated content");
+
+		mockMvc.perform(patch("/api/posts/{postId}", post.getId())
+				.header("Authorization", "Bearer " + accessToken(other))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("P002"));
+	}
+
+	@Test
+	void updatePostRejectsRequestWithoutAuthentication() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		PostUpdateRequest request = new PostUpdateRequest("updated", "updated content");
+
+		mockMvc.perform(patch("/api/posts/{postId}", post.getId())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void updatePostRejectsBlankContent() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		PostUpdateRequest request = new PostUpdateRequest("updated", " ");
+
+		mockMvc.perform(patch("/api/posts/{postId}", post.getId())
+				.header("Authorization", "Bearer " + accessToken(author))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("G001"));
+	}
+
+	@Test
+	void updatePostRejectsDeletedPost() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		post.softDelete(author.getId());
+		postRepository.saveAndFlush(post);
+		PostUpdateRequest request = new PostUpdateRequest("updated", "updated content");
+
+		mockMvc.perform(patch("/api/posts/{postId}", post.getId())
+				.header("Authorization", "Bearer " + accessToken(author))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("P001"));
+	}
+
+	@Test
+	void deletePostSoftDeletesWhenRequesterIsAuthor() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+
+		mockMvc.perform(delete("/api/posts/{postId}", post.getId())
+				.header("Authorization", "Bearer " + accessToken(author)))
+			.andExpect(status().isOk());
+
+		Post deletedPost = postRepository.findById(post.getId()).orElseThrow();
+		assertThat(deletedPost.getStatus()).isEqualTo(PostStatus.DELETED);
+		assertThat(deletedPost.getDeletedAt()).isNotNull();
+
+		mockMvc.perform(get("/api/categories/{category}/posts", "GAME"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.totalElements").value(0));
+		mockMvc.perform(get("/api/posts/{postId}", post.getId()))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void deletePostRejectsRequesterWhoIsNotAuthor() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		User other = userRepository.save(User.create("other@test.com", "encoded-password", "other"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+
+		mockMvc.perform(delete("/api/posts/{postId}", post.getId())
+				.header("Authorization", "Bearer " + accessToken(other)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("P002"));
+	}
+
+	@Test
+	void deletePostRejectsRequestWithoutAuthentication() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+
+		mockMvc.perform(delete("/api/posts/{postId}", post.getId()))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void deletePostRejectsDeletedPost() throws Exception {
+		User author = userRepository.save(User.create("author@test.com", "encoded-password", "author"));
+		Post post = postRepository.save(Post.create("GAME", "title", "content", author));
+		post.softDelete(author.getId());
+		postRepository.saveAndFlush(post);
+
+		mockMvc.perform(delete("/api/posts/{postId}", post.getId())
+				.header("Authorization", "Bearer " + accessToken(author)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("P001"));
+	}
+
+	private String accessToken(User user) {
+		return jwtTokenProvider.createAccessToken(user.getId(), UserRole.USER);
+	}
+}

--- a/src/test/java/com/neomango/post/controller/PostControllerTest.java
+++ b/src/test/java/com/neomango/post/controller/PostControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.neomango.auth.jwt.JwtTokenProvider;
+import com.neomango.comment.repository.CommentRepository;
 import com.neomango.post.dto.PostCreateRequest;
 import com.neomango.post.dto.PostUpdateRequest;
 import com.neomango.post.entity.Post;
@@ -48,6 +49,9 @@ class PostControllerTest {
 	private JwtTokenProvider jwtTokenProvider;
 
 	@Autowired
+	private CommentRepository commentRepository;
+
+	@Autowired
 	private PostRepository postRepository;
 
 	@Autowired
@@ -71,6 +75,7 @@ class PostControllerTest {
 		userCategoryMembershipRepository.deleteAll();
 		teamMemberRepository.deleteAll();
 		teamRepository.deleteAll();
+		commentRepository.deleteAll();
 		postRepository.deleteAll();
 		userRepository.deleteAll();
 	}
@@ -81,6 +86,7 @@ class PostControllerTest {
 		userCategoryMembershipRepository.deleteAll();
 		teamMemberRepository.deleteAll();
 		teamRepository.deleteAll();
+		commentRepository.deleteAll();
 		postRepository.deleteAll();
 		userRepository.deleteAll();
 	}


### PR DESCRIPTION
## 📝 개요
카테고리 별 게시판 및 댓글 CRUD
#34 
#35 

## 🚀 주요 변경 사항
도메인 변경: Post와 Comment 엔티티를 추가하고 ACTIVE/DELETED 상태 기반 Soft Delete 정책을 적용Comment는 BaseTimeEntity를 상속하며 Post/User를 LAZY 연관으로 참조

인프라: 별도 인프라 변경은 없습니다. SecurityConfig에 공개 조회 API와 인증 필요 API 정책을 반영했습니다.

